### PR TITLE
fix: chat visibility race condition and persistent fade timers

### DIFF
--- a/SSMP/Ui/Chat/ChatBox.cs
+++ b/SSMP/Ui/Chat/ChatBox.cs
@@ -308,8 +308,7 @@ internal class ChatBox : IChatBox {
         IsOpen = false;
         _scrollOffset = 0;
 
-        for (var i = 0; i < MaxMessages; i++) 
-            _messages[i]?.Hide();
+        UpdateMessageVisibility();
 
         _chatInput.SetActive(false);
         

--- a/SSMP/Ui/Chat/ChatMessage.cs
+++ b/SSMP/Ui/Chat/ChatMessage.cs
@@ -30,6 +30,16 @@ internal class ChatMessage {
     private Coroutine? _fadeCoroutine;
 
     /// <summary>
+    /// The current elapsed wait time.
+    /// </summary>
+    private float _waitElapsed;
+
+    /// <summary>
+    /// The current elapsed fade time.
+    /// </summary>
+    private float _fadeElapsed;
+
+    /// <summary>
     /// The current alpha of the message.
     /// </summary>
     private float _alpha = 1f;
@@ -69,6 +79,9 @@ internal class ChatMessage {
     public void Display(bool chatOpen) {
         _chatOpen = chatOpen;
         _textComponent.SetActive(true);
+        _waitElapsed = 0f;
+        _fadeElapsed = 0f;
+        _isFadedOut = false;
         StartFadeRoutine();
     }
 
@@ -77,7 +90,9 @@ internal class ChatMessage {
     /// </summary>
     public void Hide() {
         _isFadedOut = true;
-        SetAlpha(1f);
+        _waitElapsed = MessageStayTime;
+        _fadeElapsed = MessageFadeTime;
+        SetAlpha(0f);
         _textComponent.SetActive(false);
         StopFadeRoutine();
     }
@@ -176,21 +191,19 @@ internal class ChatMessage {
     /// </summary>
     private IEnumerator FadeRoutine() {
         // Wait at full opacity, pausing while chat is open
-        var waitElapsed = 0f;
-        while (waitElapsed < MessageStayTime) {
+        while (_waitElapsed < MessageStayTime) {
             if (!_chatOpen) {
-                waitElapsed += Time.deltaTime;
+                _waitElapsed += Time.deltaTime;
             }
 
             yield return null;
         }
 
         // Gradually fade out, pausing while chat is open
-        var elapsed = 0f;
-        while (elapsed < MessageFadeTime) {
+        while (_fadeElapsed < MessageFadeTime) {
             if (!_chatOpen) {
-                elapsed += Time.deltaTime;
-                SetAlpha(1f - (elapsed / MessageFadeTime));
+                _fadeElapsed += Time.deltaTime;
+                SetAlpha(1f - (_fadeElapsed / MessageFadeTime));
             }
 
             yield return null;


### PR DESCRIPTION
### Problem
1. **Command Feedback Race Condition**: When a user submits a command (e.g., `/tpa` in @BobbyTheCatfish 's case), `ChatBox.OnChatSubmit` invokes the command and then immediately calls `HideChatInput()`. In the previous code, `HideChatInput()` explicitly called `Hide()` on every message, which nuked any new addon feedback before it could be rendered.
2. **Fade Timer Resets**: The message fade-out timer (7.5s) was stored in a local coroutine variable. Opening and closing the chat would stop and restart the routine, resetting the timer to 0 and preventing messages from ever fading if the UI was toggled.

### Solution
- **ChatBox.cs**: Replaced the destructive `Hide()` loop in `HideChatInput()` with `UpdateMessageVisibility()`. This allows the UI to handle visibility state naturally, ensuring that newly added messages remain visible when the input area closes.
- **ChatMessage.cs**: Migrated the fade timer state (`_waitElapsed`, `_fadeElapsed`) to class-level fields. The `FadeRoutine` now correctly pauses when the chat is open and **resumes from its exact progress** when the chat closes.
