### PR TITLE
Add death animation

### DIFF
--- a/SSMP/Animation/AnimationManager.cs
+++ b/SSMP/Animation/AnimationManager.cs
@@ -656,7 +656,8 @@ internal class AnimationManager {
         { AnimationClip.BindBurstGround, BindBurst.Instance },
         { AnimationClip.BindChargeHealBurst, BindBurst.Instance },
         { AnimationClip.BindBurstAir, BindBurst.Instance },
-        { AnimationClip.RageBindBurst, BindBurst.Instance }
+        { AnimationClip.RageBindBurst, BindBurst.Instance },
+        { AnimationClip.Death, Death.Instance }
     };
 
     private static readonly Dictionary<AnimationClip, IAnimationEffect> SubAnimationEffects = new() {
@@ -764,6 +765,8 @@ internal class AnimationManager {
         // Register callbacks for tracking the start of playing animation clips
         EventHooks.SpriteAnimatorWarpClipToLocalTime += Tk2dSpriteAnimatorOnWarpClipToLocalTime;
         EventHooks.SpriteAnimatorProcessEvents += Tk2dSpriteAnimatorOnProcessEvents;
+
+        EventHooks.HeroControllerDie += OnDeath;
 
         // Register FSM hooks for certain bind actions
         HeroController.OnHeroInstanceSet += CreateBindHooks;
@@ -1356,119 +1359,24 @@ internal class AnimationManager {
     //     // _netClient.UpdateManager.UpdatePlayerAnimation(AnimationClip.HazardRespawn);
     // }
 
-    /// <summary>
-    /// Callback method for when a player death is received.
-    /// </summary>
-    /// <param name="data">The generic client data for this event.</param>
-    public void OnPlayerDeath(GenericClientData data) {
-        // And play the death animation for the ID in the packet
-        MonoBehaviourUtil.Instance.StartCoroutine(PlayDeathAnimation(data.Id));
-    }
-
     // /// <summary>
     // /// Callback method for when the local player dies.
     // /// </summary>
-    // private void OnDeath() {
-    //     // If we are not connected, there is nothing to send to
-    //     if (!_netClient.IsConnected) {
-    //         return;
-    //     }
-    //
-    //     Logger.Debug("Client has died, sending PlayerDeath data");
-    //
-    //     // Let the server know that we have died            
-    //     _netClient.UpdateManager.SetDeath();
-    // }
+    private void OnDeath(bool nonLethal, bool frostDeath) {
+        // If we are not connected, there is nothing to send to
+        if (!_netClient.IsConnected) {
+            return;
+        }
 
-    /// <summary>
-    /// Play the death animation for the player with the given ID.
-    /// </summary>
-    /// <param name="id">The ID of the player.</param>
-    /// <returns>An enumerator for the coroutine.</returns>
-    private IEnumerator PlayDeathAnimation(ushort id) {
-        Logger.Debug($"Starting death animation for ID: {id}");
-        yield break;
+        Logger.Debug("Client has died, sending PlayerDeath data");
 
-        // // Get the player object corresponding to this ID
-        // var playerObject = _playerManager.GetPlayerObject(id);
-        //
-        // // Get the sprite animator and start playing the Death animation
-        // var animator = playerObject.GetComponent<tk2dSpriteAnimator>();
-        // animator.Stop();
-        // animator.PlayFromFrame("Death", 0);
-        //
-        // // Obtain the duration for the animation
-        // var deathAnimationDuration = animator.GetClipByName("Death").Duration;
-        //
-        // // After half a second we want to throw out the nail (as defined in the FSM)
-        // yield return new WaitForSeconds(0.5f);
-        //
-        // // Calculate the duration remaining until the death animation is finished
-        // var remainingDuration = deathAnimationDuration - 0.5f;
-        //
-        // // Obtain the local player object, to copy actions from
-        // var localPlayerObject = HeroController.instance.gameObject;
-        //
-        // // Get the FSM for the Hero Death
-        // var heroDeathAnimFsm = localPlayerObject
-        //     .FindGameObjectInChildren("Hero Death")
-        //     .LocateMyFSM("Hero Death Anim");
-        //
-        // // Get the nail fling object from the Blow state
-        // var nailObject = heroDeathAnimFsm.GetFirstAction<FlingObjectsFromGlobalPool>("Blow");
-        //
-        // // Spawn it relative to the player
-        // var nailGameObject = nailObject.gameObject.Value.Spawn(
-        //     playerObject.transform.position,
-        //     Quaternion.Euler(Vector3.zero)
-        // );
-        //
-        // // Get the rigidbody component that we need to throw around
-        // var nailRigidBody = nailGameObject.GetComponent<Rigidbody2D>();
-        //
-        // // Get a random speed and angle and calculate the rigidbody velocity
-        // var speed = Random.Range(18, 22);
-        // float angle = Random.Range(50, 130);
-        // var velX = speed * Mathf.Cos(angle * ((float) System.Math.PI / 180f));
-        // var velY = speed * Mathf.Sin(angle * ((float) System.Math.PI / 180f));
-        //
-        // // Set the velocity so it starts moving
-        // nailRigidBody.velocity = new Vector2(velX, velY);
-        //
-        // // Wait for the remaining duration of the death animation
-        // yield return new WaitForSeconds(remainingDuration);
-        //
-        // // Now we can disable the player object so it isn't visible anymore
-        // playerObject.SetActive(false);
-        //
-        // // Check which direction we are facing, we need this in a few variables
-        // var facingRight = playerObject.transform.localScale.x > 0;
-        //
-        // // Depending on which direction the player was facing, choose a state
-        // var stateName = "Head Left";
-        // if (facingRight) {
-        //     stateName = "Head Right";
-        // }
-        //
-        // // Obtain a head object from the either Head states and instantiate it
-        // var headObject = heroDeathAnimFsm.GetFirstAction<CreateObject>(stateName);
-        // var headGameObject = Object.Instantiate(
-        //     headObject.gameObject.Value,
-        //     playerObject.transform.position + new Vector3(facingRight ? 0.2f : -0.2f, -0.02f, -0.01f),
-        //     Quaternion.identity
-        // );
-        //
-        // // Get the rigidbody component of the head object
-        // var headRigidBody = headGameObject.GetComponent<Rigidbody2D>();
-        //
-        // // Calculate the angle at which we are going to throw 
-        // var headAngle = 15f * Mathf.Cos((facingRight ? 100f : 80f) * ((float) System.Math.PI / 180f));
-        //
-        // // Now set the velocity as this angle
-        // headRigidBody.velocity = new Vector2(headAngle, headAngle);
-        //
-        // // Finally add required torque (according to the FSM)
-        // headRigidBody.AddTorque(facingRight ? 20f : -20f);
+        Logger.Info(frostDeath.ToString());
+        // Let the server know that we have died
+        var effectInfo = new byte[] {
+            (byte)(frostDeath ? 1 : 0)
+        };
+        Logger.Info(string.Join(", ", effectInfo));
+        _netClient.UpdateManager.UpdatePlayerAnimation(AnimationClip.Death, 0, effectInfo);
     }
 
     // /// <summary>

--- a/SSMP/Animation/AnimationManager.cs
+++ b/SSMP/Animation/AnimationManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using SSMP.Animation.Effects;
@@ -10,7 +9,6 @@ using SSMP.Game.Settings;
 using SSMP.Hooks;
 using SSMP.Internals;
 using SSMP.Networking.Client;
-using SSMP.Networking.Packet.Data;
 using SSMP.Util;
 using UnityEngine.SceneManagement;
 using Logger = SSMP.Logging.Logger;
@@ -657,7 +655,7 @@ internal class AnimationManager {
         { AnimationClip.BindChargeHealBurst, BindBurst.Instance },
         { AnimationClip.BindBurstAir, BindBurst.Instance },
         { AnimationClip.RageBindBurst, BindBurst.Instance },
-        { AnimationClip.Death, Death.Instance }
+        { AnimationClip.Death, new Death() }
     };
 
     private static readonly Dictionary<AnimationClip, IAnimationEffect> SubAnimationEffects = new() {
@@ -788,9 +786,6 @@ internal class AnimationManager {
 
         // Relinquish Control cancels a lot of effects, so we need to broadcast the end of these effects
         // On.HeroController.RelinquishControl += HeroControllerOnRelinquishControl;
-
-        // Register when the player dies to send the animation
-        // ModHooks.BeforePlayerDeadHook += OnDeath;
     }
 
     /// <summary>
@@ -815,8 +810,6 @@ internal class AnimationManager {
         // On.GameManager.HazardRespawn -= GameManagerOnHazardRespawn;
 
         // On.HeroController.RelinquishControl -= HeroControllerOnRelinquishControl;
-
-        // ModHooks.BeforePlayerDeadHook -= OnDeath;
     }
 
     /// <summary>
@@ -1370,12 +1363,10 @@ internal class AnimationManager {
 
         Logger.Debug("Client has died, sending PlayerDeath data");
 
-        Logger.Info(frostDeath.ToString());
         // Let the server know that we have died
-        var effectInfo = new byte[] {
+        byte[] effectInfo = [
             (byte)(frostDeath ? 1 : 0)
-        };
-        Logger.Info(string.Join(", ", effectInfo));
+        ];
         _netClient.UpdateManager.UpdatePlayerAnimation(AnimationClip.Death, 0, effectInfo);
     }
 

--- a/SSMP/Animation/Effects/Death.cs
+++ b/SSMP/Animation/Effects/Death.cs
@@ -9,26 +9,35 @@ using Object = UnityEngine.Object;
 
 namespace SSMP.Animation.Effects;
 
+/// <summary>
+/// Animation effect for the death of the player.
+/// </summary>
 internal class Death : AnimationEffect {
-    public static Death Instance = new();
+    /// <summary>
+    /// Name of the game object for the death particles.
+    /// </summary>
+    private const string DeathParticleObjectName = "Low Health Leak";
 
+    /// <summary>
+    /// Cached game object for the death particles.
+    /// </summary>
     private static GameObject? _deathParticles;
-    private const string ParticleObjectName = "Low Health Leak";
 
-    public override byte[]? GetEffectInfo() {
+    /// <inheritdoc/>
+    public override byte[] GetEffectInfo() {
         var frosted = HeroController.instance.cState.isFrostDeath;
 
-        var info = new byte[] {
+        byte[] info = [
             (byte)(frosted ? 1 : 0)
-        };
+        ];
 
         return info;
     }
 
     /// <inheritdoc/>
     public override void Play(GameObject playerObject, CrestType crestType, byte[]? effectInfo) {
-        // Play frost death if applicable
-        if (effectInfo != null && effectInfo.Length == 1 && effectInfo[0] == 1) {
+        // Play frost death if applicable (effect info contains a single byte with the value '1')
+        if (effectInfo is [1]) {
             MonoBehaviourUtil.Instance.StartCoroutine(PlayFrostDeath(playerObject));
             return;
         } 
@@ -38,10 +47,10 @@ internal class Death : AnimationEffect {
     }
 
     /// <summary>
-    /// Plays the frost death animation
+    /// Plays the frost death animation.
     /// </summary>
     /// <param name="playerObject">The GameObject representing the player.</param>
-    private IEnumerator PlayFrostDeath(GameObject playerObject) {
+    private static IEnumerator PlayFrostDeath(GameObject playerObject) {
         // Find frost death prefab
         var prefab = HeroController.instance.heroDeathFrostPrefab;
         if (prefab == null) {
@@ -57,9 +66,19 @@ internal class Death : AnimationEffect {
         var localCrystalSlow = prefab.FindGameObjectInChildren("Particle_Crystal Slow");
         var localCrystalFinal = prefab.FindGameObjectInChildren("Particle_Crystal Final");
 
-        var growthTime = 3f;
-        var crystalSlow = EffectUtils.SpawnGlobalPoolObject(localCrystalSlow, playerObject.transform, growthTime, true);
-        var crystalFinal = EffectUtils.SpawnGlobalPoolObject(localCrystalFinal, playerObject.transform, growthTime, true);
+        const float growthTime = 3f;
+        var crystalSlow = EffectUtils.SpawnGlobalPoolObject(
+            localCrystalSlow, 
+            playerObject.transform, 
+            growthTime, 
+            true
+        );
+        var crystalFinal = EffectUtils.SpawnGlobalPoolObject(
+            localCrystalFinal, 
+            playerObject.transform, 
+            growthTime, 
+            true
+        );
 
         if (crystalSlow == null || crystalFinal == null) {
             yield break;
@@ -73,8 +92,12 @@ internal class Death : AnimationEffect {
 
         // Transition from growing the crystals to exploding them
         var localDestroyEffects = prefab.FindGameObjectInChildren("Destroy Effects");
-        var destroyEffects = EffectUtils.SpawnGlobalPoolObject(localDestroyEffects, playerObject.transform, 5);
-        if (destroyEffects.TryGetComponent<CameraShakeOnEnable>(out var shaker)) {
+        var destroyEffects = EffectUtils.SpawnGlobalPoolObject(
+            localDestroyEffects, 
+            playerObject.transform, 
+            5
+        );
+        if (destroyEffects != null && destroyEffects.TryGetComponent<CameraShakeOnEnable>(out var shaker)) {
             Object.DestroyImmediate(shaker);
         }
 
@@ -83,9 +106,17 @@ internal class Death : AnimationEffect {
         playerObject.GetComponent<tk2dSprite>().SetSprite("wall_puff0004");
 
         // Spawn the frosted hornet object
-        var frostedDuration = 3;
+        const int frostedDuration = 3;
         var localFrostDeath = prefab.FindGameObjectInChildren("Hornet_Frosted");
-        var frostDeath = EffectUtils.SpawnGlobalPoolObject(localFrostDeath, playerObject.transform, frostedDuration + 1.1f);
+        var frostDeath = EffectUtils.SpawnGlobalPoolObject(
+            localFrostDeath, 
+            playerObject.transform, 
+            frostedDuration + 1.1f
+        );
+        if (frostDeath == null) {
+            yield break;
+        }
+
         frostDeath.transform.localPosition = playerObject.transform.position + new Vector3(0.11f, 0, -0.18f);
 
         // Fade out and play particles
@@ -95,10 +126,10 @@ internal class Death : AnimationEffect {
     }
 
     /// <summary>
-    /// Plays the normal death animation
+    /// Plays the normal death animation.
     /// </summary>
     /// <param name="playerObject">The GameObject representing the player.</param>
-    private IEnumerator PlayDeath(GameObject playerObject) {
+    private static IEnumerator PlayDeath(GameObject playerObject) {
         // Get/create a death particle system
         if (!CreateParticles(playerObject, out var particles)) {
             yield break;
@@ -120,16 +151,18 @@ internal class Death : AnimationEffect {
     }
 
     /// <summary>
-    /// Spawns the particle system that is created when a player hits their cocoon
+    /// Spawns the particle system that is created when a player hits their cocoon.
     /// </summary>
     /// <param name="playerObject">The player object to spawn the particles on</param>
-    private void SpawnCocoonParticles(GameObject playerObject) {
+    private static void SpawnCocoonParticles(GameObject playerObject) {
         // Get the cocoon prefab
         var manager = GameManager.instance.GetSceneManager().GetComponent<CustomSceneManager>();
         var localCocoon = manager.heroCorpsePrefab;
 
         // Find the particle systems inside of it
-        var localCocoonParticles = localCocoon.FindGameObjectInChildren("Core")?.FindGameObjectInChildren("Pt Spider Fall");
+        var localCocoonParticles = localCocoon
+                                   .FindGameObjectInChildren("Core")?
+                                   .FindGameObjectInChildren("Pt Spider Fall");
         if (localCocoonParticles == null) {
             Logger.Info("No particles");
             return;
@@ -145,9 +178,12 @@ internal class Death : AnimationEffect {
     /// <param name="playerObject">The player's object.</param>
     /// <param name="deathParticles">The player's 'Low Health Leak' object, or null if not found.</param>
     /// <returns>true if the 'Low Health Leak' GameObject is successfully found and bound; otherwise, false.</returns>
-    protected bool CreateParticles(GameObject playerObject, [MaybeNullWhen(false)] out GameObject deathParticles) {
+    private static bool CreateParticles(
+        GameObject playerObject, 
+        [MaybeNullWhen(false)] out GameObject deathParticles
+    ) {
         // Find the reference object
-        _deathParticles ??= HeroController.instance.gameObject.FindGameObjectInChildren(ParticleObjectName);
+        _deathParticles ??= HeroController.instance.gameObject.FindGameObjectInChildren(DeathParticleObjectName);
         if (_deathParticles == null) {
             Logger.Warn("Could not find local Bind Effects object in hero object");
             deathParticles = null;
@@ -155,14 +191,14 @@ internal class Death : AnimationEffect {
         }
 
         // Find the existing particles for the player object
-        deathParticles = playerObject.FindGameObjectInChildren(ParticleObjectName);
+        deathParticles = playerObject.FindGameObjectInChildren(DeathParticleObjectName);
 
         // If not found, make it!
         if (deathParticles == null) {
             deathParticles = Object.Instantiate(_deathParticles);
             deathParticles.transform.SetParentReset(playerObject.transform);
             deathParticles.transform.SetLocalPositionZ(0.2f);
-            deathParticles.name = ParticleObjectName;
+            deathParticles.name = DeathParticleObjectName;
             
             // Add timer to turn off
             var deactivator = deathParticles.AddComponent<DeactivateAfterDelay>();

--- a/SSMP/Animation/Effects/Death.cs
+++ b/SSMP/Animation/Effects/Death.cs
@@ -1,0 +1,179 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using HutongGames.PlayMaker.Actions;
+using SSMP.Internals;
+using SSMP.Util;
+using UnityEngine;
+using Logger = SSMP.Logging.Logger;
+using Object = UnityEngine.Object;
+
+namespace SSMP.Animation.Effects;
+
+internal class Death : AnimationEffect {
+    public static Death Instance = new();
+
+    private static GameObject? _deathParticles;
+    private const string ParticleObjectName = "Low Health Leak";
+
+    public override byte[]? GetEffectInfo() {
+        var frosted = HeroController.instance.cState.isFrostDeath;
+
+        var info = new byte[] {
+            (byte)(frosted ? 1 : 0)
+        };
+
+        return info;
+    }
+
+    /// <inheritdoc/>
+    public override void Play(GameObject playerObject, CrestType crestType, byte[]? effectInfo) {
+        // Play frost death if applicable
+        if (effectInfo != null && effectInfo.Length == 1 && effectInfo[0] == 1) {
+            MonoBehaviourUtil.Instance.StartCoroutine(PlayFrostDeath(playerObject));
+            return;
+        } 
+
+        // Otherwise just play the normal animation
+        MonoBehaviourUtil.Instance.StartCoroutine(PlayDeath(playerObject));
+    }
+
+    /// <summary>
+    /// Plays the frost death animation
+    /// </summary>
+    /// <param name="playerObject">The GameObject representing the player.</param>
+    private IEnumerator PlayFrostDeath(GameObject playerObject) {
+        // Find frost death prefab
+        var prefab = HeroController.instance.heroDeathFrostPrefab;
+        if (prefab == null) {
+            yield break;
+        }
+
+        // Play freeze audio
+        var fsm = prefab.LocateMyFSM("Hero Death Anim");
+        var audio = fsm.GetFirstAction<AudioPlayerOneShotSingle>("Start");
+        AudioUtil.PlayAudio(audio, playerObject);
+
+        // Spawn the two crystal growth particle systems
+        var localCrystalSlow = prefab.FindGameObjectInChildren("Particle_Crystal Slow");
+        var localCrystalFinal = prefab.FindGameObjectInChildren("Particle_Crystal Final");
+
+        var crystalSlow = EffectUtils.SpawnGlobalPoolObject(localCrystalSlow, playerObject.transform, 2.45f, true);
+        var crystalFinal = EffectUtils.SpawnGlobalPoolObject(localCrystalFinal, playerObject.transform, 2.45f, true);
+
+        if (crystalSlow == null || crystalFinal == null) {
+            yield break;
+        }
+
+        // Reset their positions
+        crystalSlow.transform.localPosition = new Vector3(-0.32f, 0, -2.22f);
+        crystalFinal.transform.localPosition = new Vector3(-0.22f, -0.04f, -2.2f);
+
+        yield return new WaitForSeconds(2.45f);
+
+        // Transition from growing the crystals to exploding them
+        var localDestroyEffects = prefab.FindGameObjectInChildren("Destroy Effects");
+        var destroyEffects = EffectUtils.SpawnGlobalPoolObject(localDestroyEffects, playerObject.transform, 5);
+        if (destroyEffects.TryGetComponent<CameraShakeOnEnable>(out var shaker)) {
+            Object.DestroyImmediate(shaker);
+        }
+
+        // "hide" the player (assign a very small texture)
+        playerObject.GetComponent<tk2dSpriteAnimator>().Stop();
+        playerObject.GetComponent<tk2dSprite>().SetSprite("wall_puff0004");
+
+        // Spawn the frosted hornet object
+        var frostedDuration = 3;
+        var localFrostDeath = prefab.FindGameObjectInChildren("Hornet_Frosted");
+        var frostDeath = EffectUtils.SpawnGlobalPoolObject(localFrostDeath, playerObject.transform, frostedDuration + 1.1f);
+        frostDeath.transform.localPosition = playerObject.transform.position + new Vector3(0.11f, 0, -0.18f);
+
+        // Fade out and play particles
+        yield return new WaitForSeconds(frostedDuration);
+        frostDeath.AddComponent<SimpleFadeOut>();
+        SpawnCocoonParticles(frostDeath);
+    }
+
+    /// <summary>
+    /// Plays the normal death animation
+    /// </summary>
+    /// <param name="playerObject">The GameObject representing the player.</param>
+    private IEnumerator PlayDeath(GameObject playerObject) {
+        // Get/create a death particle system
+        if (!CreateParticles(playerObject, out var particles)) {
+            yield break;
+        }
+
+        // Enable the system by turning on emission
+        var particleSystem = particles.GetComponent<ParticleSystem>();
+        var emission = particleSystem.emission;
+        emission.enabled = true;
+        
+        // Refresh particle system
+        particles.SetActive(false);
+        particles.SetActive(true);
+
+        // Disable leak particle emission after time, then spawn black particles
+        yield return new WaitForSeconds(4);
+        emission.enabled = false;
+        SpawnCocoonParticles(playerObject);
+    }
+
+    /// <summary>
+    /// Spawns the particle system that is created when a player hits their cocoon
+    /// </summary>
+    /// <param name="playerObject">The player object to spawn the particles on</param>
+    private void SpawnCocoonParticles(GameObject playerObject) {
+        // Get the cocoon prefab
+        var manager = GameManager.instance.GetSceneManager().GetComponent<CustomSceneManager>();
+        var localCocoon = manager.heroCorpsePrefab;
+
+        // Find the particle systems inside of it
+        var localCocoonParticles = localCocoon.FindGameObjectInChildren("Core")?.FindGameObjectInChildren("Pt Spider Fall");
+        if (localCocoonParticles == null) {
+            Logger.Info("No particles");
+            return;
+        }
+
+        // Spawn the particles
+        EffectUtils.SpawnGlobalPoolObject(localCocoonParticles, playerObject.transform, 10f);
+    }
+
+    /// <summary>
+    /// Attempts to locate and bind the 'Low Health Leak' GameObject to the specified player object.
+    /// </summary>
+    /// <param name="playerObject">The player's object.</param>
+    /// <param name="deathParticles">The player's 'Low Health Leak' object, or null if not found.</param>
+    /// <returns>true if the 'Low Health Leak' GameObject is successfully found and bound; otherwise, false.</returns>
+    protected bool CreateParticles(GameObject playerObject, [MaybeNullWhen(false)] out GameObject deathParticles) {
+        // Find the reference object
+        _deathParticles ??= HeroController.instance.gameObject.FindGameObjectInChildren(ParticleObjectName);
+        if (_deathParticles == null) {
+            Logger.Warn("Could not find local Bind Effects object in hero object");
+            deathParticles = null;
+            return false;
+        }
+
+        // Find the existing particles for the player object
+        deathParticles = playerObject.FindGameObjectInChildren(ParticleObjectName);
+
+        // If not found, make it!
+        if (deathParticles == null) {
+            deathParticles = Object.Instantiate(_deathParticles);
+            deathParticles.transform.SetParentReset(playerObject.transform);
+            deathParticles.transform.SetLocalPositionZ(0.2f);
+            deathParticles.name = ParticleObjectName;
+            
+            // Add timer to turn off
+            var deactivator = deathParticles.AddComponent<DeactivateAfterDelay>();
+            deactivator.time = 4f;
+
+            // Ensure the particle system turns on automatically
+            var particleSystem = deathParticles.GetComponent<ParticleSystem>();
+            var main = particleSystem.main;
+            main.playOnAwake = true;
+        }
+
+        // Particles were found or created!
+        return true;
+    }
+}

--- a/SSMP/Animation/Effects/Death.cs
+++ b/SSMP/Animation/Effects/Death.cs
@@ -57,8 +57,9 @@ internal class Death : AnimationEffect {
         var localCrystalSlow = prefab.FindGameObjectInChildren("Particle_Crystal Slow");
         var localCrystalFinal = prefab.FindGameObjectInChildren("Particle_Crystal Final");
 
-        var crystalSlow = EffectUtils.SpawnGlobalPoolObject(localCrystalSlow, playerObject.transform, 2.45f, true);
-        var crystalFinal = EffectUtils.SpawnGlobalPoolObject(localCrystalFinal, playerObject.transform, 2.45f, true);
+        var growthTime = 3f;
+        var crystalSlow = EffectUtils.SpawnGlobalPoolObject(localCrystalSlow, playerObject.transform, growthTime, true);
+        var crystalFinal = EffectUtils.SpawnGlobalPoolObject(localCrystalFinal, playerObject.transform, growthTime, true);
 
         if (crystalSlow == null || crystalFinal == null) {
             yield break;
@@ -68,7 +69,7 @@ internal class Death : AnimationEffect {
         crystalSlow.transform.localPosition = new Vector3(-0.32f, 0, -2.22f);
         crystalFinal.transform.localPosition = new Vector3(-0.22f, -0.04f, -2.2f);
 
-        yield return new WaitForSeconds(2.45f);
+        yield return new WaitForSeconds(growthTime);
 
         // Transition from growing the crystals to exploding them
         var localDestroyEffects = prefab.FindGameObjectInChildren("Destroy Effects");

--- a/SSMP/Animation/Effects/SlashBase.cs
+++ b/SSMP/Animation/Effects/SlashBase.cs
@@ -154,8 +154,7 @@ internal abstract class SlashBase : ParryableEffect {
 
         var relAudioSource = AudioUtil.GetAudioSourceObject(playerObject);
         relAudioSource.transform.parent = slashParent.transform;
-        relAudioSource.clip = audio.clip;
-        relAudioSource.Play();
+        relAudioSource.PlayOneShot(audio.clip);
 
         mesh.enabled = true;
 

--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -411,10 +411,6 @@ internal class ClientManager : IClientManager {
             ClientUpdatePacketId.PlayerSetting,
             OnPlayerSettingUpdate
         );
-        _packetManager.RegisterClientUpdatePacketHandler<GenericClientData>(
-            ClientUpdatePacketId.PlayerDeath,
-            OnPlayerDeath
-        );
 
         // Register packet handlers related to full synchronisation
         if (_fullSynchronisation) {
@@ -456,7 +452,6 @@ internal class ClientManager : IClientManager {
         _packetManager.DeregisterClientUpdatePacketHandler(ClientUpdatePacketId.ServerSettingsUpdated);
         _packetManager.DeregisterClientUpdatePacketHandler(ClientUpdatePacketId.ChatMessage);
         _packetManager.DeregisterClientUpdatePacketHandler(ClientUpdatePacketId.PlayerSetting);
-        _packetManager.DeregisterClientUpdatePacketHandler(ClientUpdatePacketId.PlayerDeath);
 
         if (_fullSynchronisation) {
             _packetManager.DeregisterClientUpdatePacketHandler(ClientUpdatePacketId.EntitySpawn);
@@ -1307,14 +1302,6 @@ internal class ClientManager : IClientManager {
                 playerData.CrestType = settingUpdate.CrestType;
             }
         }
-    }
-
-    /// <summary>
-    /// Callback method for when a player death packet is received.
-    /// </summary>
-    /// <param name="deathData">The GenericClientData packet data.</param>
-    private void OnPlayerDeath(GenericClientData deathData) {
-        _animationManager.OnPlayerDeath(deathData);
     }
 
     /// <summary>

--- a/SSMP/Hooks/EventHooks.cs
+++ b/SSMP/Hooks/EventHooks.cs
@@ -77,6 +77,11 @@ public static class EventHooks {
     private static Hook? _heroControllerUpdateHook;
 
     /// <summary>
+    /// Hook for HeroController.Die
+    /// </summary>
+    private static Hook? _heroControllerDieHook;
+
+    /// <summary>
     /// Hook for GameMap.PositionCompassAndCorpse.
     /// </summary>
     private static Hook? _gameMapPositionCompassAndCorpseHook;
@@ -161,6 +166,12 @@ public static class EventHooks {
     /// Event that is called when HeroController.Update is called.
     /// </summary>
     public static event Action<HeroController>? HeroControllerUpdate;
+
+    /// <summary>
+    /// Event that executes when HeroController.Die is called
+    /// The first parameter is nonLethal, the second is frostDeath.
+    /// </summary>
+    public static event Action<bool, bool>? HeroControllerDie;
 
     /// <summary>
     /// Event that is called when GameMap.PositionCompassAndCorpse is called.
@@ -285,6 +296,11 @@ public static class EventHooks {
         _heroControllerUpdateHook = new Hook(
             typeof(HeroController).GetMethod(nameof(HeroController.Update), BindingFlags),
             OnHeroControllerUpdate
+        );
+
+        _heroControllerDieHook = new Hook(
+            typeof(HeroController).GetMethod(nameof(HeroController.Die), BindingFlags),
+            OnHeroControllerDie
         );
 
         _gameMapPositionCompassAndCorpseHook = new Hook(
@@ -446,6 +462,17 @@ public static class EventHooks {
         orig(self);
 
         HeroControllerUpdate?.Invoke(self);
+    }
+
+    private static IEnumerator OnHeroControllerDie(
+        Func<HeroController, bool, bool, IEnumerator> orig,
+        HeroController self,
+        bool nonLethal,
+        bool frostDeath
+        ) {
+        HeroControllerDie?.Invoke(nonLethal, frostDeath);
+
+        return orig(self, nonLethal, frostDeath);
     }
 
     private static void OnGameMapPositionCompassAndCorpse(Action<GameMap> orig, GameMap self) {


### PR DESCRIPTION
Adds animations for player deaths. The hook method is a bit more complicated than i'd like, but alas. Team Cherry decided to call their HeroController.OnDeath action *before* setting any cState properties. I figured it made more sense as an animation effect rather than a player update, but I can change it if need be. There are likely other leftovers that need to be removed as well.

Also fixes a bug where some attack sounds lingered and replayed, seemingly replacing other sound effects. No clue what caused it, but playing the audio as a oneshot seemed to fix it.