### PR TITLE
Add safety for mismatch between DTLS buffer and received data

### DIFF
--- a/SSMP/Networking/Client/DtlsClient.cs
+++ b/SSMP/Networking/Client/DtlsClient.cs
@@ -1,12 +1,13 @@
 using System;
+using System.Buffers;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using Org.BouncyCastle.Tls;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using SSMP.Logging;
-using SSMP.Networking.Transport.UDP;
 
 namespace SSMP.Networking.Client;
 
@@ -198,58 +199,54 @@ internal class DtlsClient {
     /// Continuously tries to receive data from the socket until cancellation is requested.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token to cancel the loop.</param>
-    private void SocketReceiveLoop(CancellationToken cancellationToken) {
-        while (!cancellationToken.IsCancellationRequested) {
-            if (_socket == null) {
-                Logger.Error("Socket was null during receive call");
-                break;
-            }
-
-            EndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
-
-            int numReceived;
-            var buffer = new byte[MaxPacketSize];
-
-            try {
-                numReceived = _socket.ReceiveFrom(
-                    buffer,
-                    SocketFlags.None,
-                    ref endPoint
-                );
-            } catch (SocketException e) when (e.SocketErrorCode == SocketError.Interrupted ||
-                                              e.SocketErrorCode == SocketError.ConnectionReset) {
-                break;
-            } catch (SocketException e) when (e.SocketErrorCode == SocketError.TimedOut) {
-                continue;
-            } catch (ObjectDisposedException) {
-                break;
-            }
-
-            if (_clientDatagramTransport == null) {
-                break;
-            }
-
-            // Create a copy of the buffer for this specific packet. The original buffer will be reused in the next iteration
-            var packetBuffer = new byte[numReceived];
-            Array.Copy(buffer, 0, packetBuffer, 0, numReceived);
-
-            var added = false;
-            try {
-                // Use the copy, not the original buffer
-                _clientDatagramTransport.ReceivedDataCollection.Add(new UdpDatagramTransport.ReceivedData {
-                    Buffer = packetBuffer,
-                    Length = numReceived
-                }, cancellationToken);
-                added = true;
-            } catch (OperationCanceledException) {
-                // Expected during disconnect
-            } catch (InvalidOperationException) {
-                // Collection might be marked as complete for adding
-            }
-
-            // Collection disposed, completed, or cancelled
-            if (!added) break;
+    private void SocketReceiveLoop(CancellationToken cancellationToken)
+    {
+        if (_socket == null)
+        {
+            Logger.Error("Socket was null when starting receive loop");
+            return;
         }
+
+        if (_clientDatagramTransport == null)
+        {
+            Logger.Error("ClientDatagramTransport was null when starting receive loop");
+            return;
+        }
+
+        var rentedBuffer = ArrayPool<byte>.Shared.Rent(MaxPacketSize);
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                EndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
+                int numReceived;
+
+                try { numReceived = _socket.ReceiveFrom(rentedBuffer, SocketFlags.None, ref endPoint); }
+                catch (SocketException e) when (e.SocketErrorCode is SocketError.Interrupted or SocketError.ConnectionReset) { break; }
+                catch (SocketException e) when (e.SocketErrorCode == SocketError.TimedOut) { continue; }
+                catch (SocketException e) { Logger.Error($"Unexpected socket error in receive loop: {e.SocketErrorCode}"); break; }
+                catch (ObjectDisposedException) { break; }
+                
+                // TODO: If SocketReceiveLoop shows up as an allocation hotspot in profiling, consider reusable buffers
+                // TODO: (for example ArrayPool<byte> or an owned-memory pattern). For now we copy into a dedicated array
+                // TODO: because BouncyCastle's buffer ownership and lifetime expectations are not explicit enough to safely reuse buffers.
+                var packetBuffer = new byte[numReceived];
+                Array.Copy(rentedBuffer, 0, packetBuffer, 0, numReceived);
+
+                try
+                {
+                    var added = _clientDatagramTransport.TryEnqueueReceivedData(
+                        packetBuffer,
+                        numReceived,
+                        cancellationToken
+                    );
+
+                    if (!added) break;
+                }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+        finally { ArrayPool<byte>.Shared.Return(rentedBuffer); }
     }
 
     /// <summary>

--- a/SSMP/Networking/Client/DtlsClient.cs
+++ b/SSMP/Networking/Client/DtlsClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -199,54 +198,57 @@ internal class DtlsClient {
     /// Continuously tries to receive data from the socket until cancellation is requested.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token to cancel the loop.</param>
-    private void SocketReceiveLoop(CancellationToken cancellationToken)
-    {
-        if (_socket == null)
-        {
+    private void SocketReceiveLoop(CancellationToken cancellationToken) {
+        if (_socket == null) {
             Logger.Error("Socket was null when starting receive loop");
             return;
         }
 
-        if (_clientDatagramTransport == null)
-        {
+        if (_clientDatagramTransport == null) {
             Logger.Error("ClientDatagramTransport was null when starting receive loop");
             return;
         }
 
         var rentedBuffer = ArrayPool<byte>.Shared.Rent(MaxPacketSize);
-        try
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                EndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
-                int numReceived;
+        while (!cancellationToken.IsCancellationRequested) {
+            EndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
+            int numReceived;
 
-                try { numReceived = _socket.ReceiveFrom(rentedBuffer, SocketFlags.None, ref endPoint); }
-                catch (SocketException e) when (e.SocketErrorCode is SocketError.Interrupted or SocketError.ConnectionReset) { break; }
-                catch (SocketException e) when (e.SocketErrorCode == SocketError.TimedOut) { continue; }
-                catch (SocketException e) { Logger.Error($"Unexpected socket error in receive loop: {e.SocketErrorCode}"); break; }
-                catch (ObjectDisposedException) { break; }
-                
-                // TODO: If SocketReceiveLoop shows up as an allocation hotspot in profiling, consider reusable buffers
-                // TODO: (for example ArrayPool<byte> or an owned-memory pattern). For now we copy into a dedicated array
-                // TODO: because BouncyCastle's buffer ownership and lifetime expectations are not explicit enough to safely reuse buffers.
-                var packetBuffer = new byte[numReceived];
-                Array.Copy(rentedBuffer, 0, packetBuffer, 0, numReceived);
+            try {
+                numReceived = _socket.ReceiveFrom(rentedBuffer, SocketFlags.None, ref endPoint);
+            } catch (SocketException e) when (
+                e.SocketErrorCode is SocketError.Interrupted or SocketError.ConnectionReset
+            ) {
+                break;
+            } catch (SocketException e) when (e.SocketErrorCode == SocketError.TimedOut) {
+                continue;
+            } catch (SocketException e) {
+                Logger.Error($"Unexpected socket error in receive loop: {e.SocketErrorCode}");
+                break;
+            } catch (ObjectDisposedException) {
+                break;
+            }
 
-                try
-                {
-                    var added = _clientDatagramTransport.TryEnqueueReceivedData(
-                        packetBuffer,
-                        numReceived,
-                        cancellationToken
-                    );
+            // TODO: If SocketReceiveLoop shows up as an allocation hotspot in profiling, consider reusable buffers
+            // TODO: (for example ArrayPool<byte> or an owned-memory pattern). For now we copy into a dedicated array
+            // TODO: because BouncyCastle's buffer ownership and lifetime expectations are not explicit enough to safely reuse buffers.
+            var packetBuffer = new byte[numReceived];
+            Array.Copy(rentedBuffer, 0, packetBuffer, 0, numReceived);
 
-                    if (!added) break;
-                }
-                catch (OperationCanceledException) { break; }
+            try {
+                var added = _clientDatagramTransport.TryEnqueueReceivedData(
+                    packetBuffer,
+                    numReceived,
+                    cancellationToken
+                );
+
+                if (!added) break;
+            } catch (OperationCanceledException) {
+                break;
             }
         }
-        finally { ArrayPool<byte>.Shared.Return(rentedBuffer); }
+        
+        ArrayPool<byte>.Shared.Return(rentedBuffer);
     }
 
     /// <summary>

--- a/SSMP/Networking/Server/DtlsServer.cs
+++ b/SSMP/Networking/Server/DtlsServer.cs
@@ -263,7 +263,7 @@ internal class DtlsServer {
             if (TryRouteToExistingConnection(connInfo, ipEndPoint, buffer, numReceived, cancellationToken))
                 return;
 
-            // Connection was in a terminal or broken state -> evict and fall through to treat as new.
+            // Connection was in a terminal or broken state -> evict and fall through to treat as new
             _connections.TryRemove(ipEndPoint, out _);
 
             if (connInfo.Client != null)
@@ -295,8 +295,9 @@ internal class DtlsServer {
                     if (connInfo.DatagramTransport.TryEnqueueReceivedData(
                             buffer, numReceived, cancellationToken,
                             $"ProcessReceivedPacket(handshaking, endpoint={ipEndPoint})"
-                        ))
+                    )) {
                         return true;
+                    }
 
                     Logger.Warn($"Failed to enqueue datagram for handshaking connection {ipEndPoint}. Evicting.");
                     return false;
@@ -305,12 +306,12 @@ internal class DtlsServer {
                     if (!connInfo.DatagramTransport.TryEnqueueReceivedData(
                             buffer, numReceived, cancellationToken,
                             $"ProcessReceivedPacket(connected, endpoint={ipEndPoint})"
-                        ))
+                    )) {
                         Logger.Warn($"Failed to enqueue datagram for connected client {ipEndPoint}. Packet dropped.");
+                    }
 
                     // Enqueue failure on a connected client is non-fatal -> keep the connection.
                     return true;
-
                 default:
                     return false;
             }
@@ -344,8 +345,11 @@ internal class DtlsServer {
         }
 
         if (!transport.TryEnqueueReceivedData(
-                buffer, numReceived, cancellationToken, $"ProcessReceivedPacket(new-connection, endpoint={ipEndPoint})"
-            )) {
+            buffer, 
+            numReceived, 
+            cancellationToken, 
+            $"ProcessReceivedPacket(new-connection, endpoint={ipEndPoint})"
+        )) {
             Logger.Warn($"Failed to enqueue first datagram for new connection {ipEndPoint}. Aborting handshake.");
             _connections.TryRemove(ipEndPoint, out _);
             transport.Dispose();
@@ -556,4 +560,3 @@ internal class DtlsServer {
         public Thread? ReceiveThread { get; set; }
     }
 }
-

--- a/SSMP/Networking/Server/DtlsServer.cs
+++ b/SSMP/Networking/Server/DtlsServer.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Org.BouncyCastle.Tls;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using SSMP.Logging;
-using SSMP.Networking.Transport.UDP;
 
 namespace SSMP.Networking.Server;
 
@@ -20,7 +19,7 @@ internal class DtlsServer {
     /// The maximum packet size for sending and receiving DTLS packets.
     /// </summary>
     public const int MaxPacketSize = 1400;
-    
+
     /// <summary>
     /// The socket instance for the underlying networking.
     /// The server only uses a single socket for all connections given that with UDP, we cannot create more than one
@@ -83,6 +82,7 @@ internal class DtlsServer {
             _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             _socket.Bind(new IPEndPoint(IPAddress.Any, _port));
         }
+
         _socketReceiveThread = new Thread(() => SocketReceiveLoop(_cancellationTokenSource.Token)) {
             IsBackground = true
         };
@@ -111,6 +111,7 @@ internal class DtlsServer {
                 Logger.Warn("Socket receive thread did not exit within timeout, abandoning");
             }
         }
+
         _socketReceiveThread = null;
 
         _tlsServer?.Cancel();
@@ -119,7 +120,7 @@ internal class DtlsServer {
         // We just cancel tokens and close transports. The threads are background and will die.
         foreach (var kvp in _connections) {
             var connInfo = kvp.Value;
-            lock (connInfo) {
+            lock (connInfo.SyncRoot) {
                 if (connInfo is { State: ConnectionState.Connected, Client: not null }) {
                     // Signal cancellation but don't join
                     connInfo.Client.ReceiveLoopTokenSource.Cancel();
@@ -129,6 +130,7 @@ internal class DtlsServer {
                 } else {
                     connInfo.DatagramTransport.Close();
                 }
+
                 connInfo.State = ConnectionState.Disconnected;
             }
         }
@@ -148,7 +150,7 @@ internal class DtlsServer {
             return;
         }
 
-        lock (connInfo) {
+        lock (connInfo.SyncRoot) {
             if (connInfo.State != ConnectionState.Connected || connInfo.Client == null) {
                 Logger.Warn($"Connection {endPoint} not in connected state");
                 return;
@@ -158,7 +160,6 @@ internal class DtlsServer {
 
             InternalDisconnectClient(connInfo.Client);
             connInfo.State = ConnectionState.Disconnected;
-
         }
 
         _connections.TryRemove(endPoint, out _);
@@ -253,101 +254,131 @@ internal class DtlsServer {
     /// <param name="cancellationToken">The cancellation token for checking whether this task is requested to cancel.
     /// </param>
     private void ProcessReceivedPacket(
-        IPEndPoint ipEndPoint, 
-        byte[] buffer, 
-        int numReceived, 
+        IPEndPoint ipEndPoint,
+        byte[] buffer,
+        int numReceived,
         CancellationToken cancellationToken
     ) {
-        // 1. Attempt to route to an existing connection
         if (_connections.TryGetValue(ipEndPoint, out var connInfo)) {
-            bool shouldRemove;
-            DtlsServerClient? clientToDisconnect = null;
+            if (TryRouteToExistingConnection(connInfo, ipEndPoint, buffer, numReceived, cancellationToken))
+                return;
 
-            lock (connInfo) {
-                if (connInfo.State == ConnectionState.Handshaking) {
-                    try {
-                        var data = new UdpDatagramTransport.ReceivedData { Buffer = buffer, Length = numReceived };
-                        connInfo.DatagramTransport.ReceivedDataCollection.Add(data, cancellationToken);
-                        return; // Successfully routed
-                    } catch (Exception) {
-                        shouldRemove = true;
-                    }
-                } else if (connInfo.State == ConnectionState.Connected) {
-                    try {
-                        var data = new UdpDatagramTransport.ReceivedData { Buffer = buffer, Length = numReceived };
-                        connInfo.DatagramTransport.ReceivedDataCollection.Add(data, cancellationToken);
-                    } catch (Exception) {
-                        // Silently ignore
-                    }
-                    return; // Successfully routed or ignored
-                } else {
-                    // Disconnecting or Disconnected
-                    shouldRemove = true;
-                }
-            }
-
-            // Handle removal if the state was invalid
-            if (!shouldRemove) return;
-            
+            // Connection was in a terminal or broken state -> evict and fall through to treat as new.
             _connections.TryRemove(ipEndPoint, out _);
-            if (clientToDisconnect != null) {
-                Task.Run(() => InternalDisconnectClient(clientToDisconnect), cancellationToken);
-            }
-            
-            // Fall through: We removed the bad connection, now treat this as a new connection attempt
+
+            if (connInfo.Client != null)
+                Task.Run(() => InternalDisconnectClient(connInfo.Client), cancellationToken);
         }
 
-        // 2. Handle new connection attempt
-        Logger.Debug($"DtlsServer: Received packet from new endpoint {ipEndPoint} ({numReceived} bytes). Starting handshake.");
-        var newTransport = new ServerDatagramTransport(_socket!) {
-            IPEndPoint = ipEndPoint
-        };
+        StartNewConnection(ipEndPoint, buffer, numReceived, cancellationToken);
+    }
 
+    /// <summary>
+    /// Attempts to route <paramref name="buffer"/> to <paramref name="connInfo"/>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the datagram was handled (routed or intentionally dropped);
+    /// <see langword="false"/> if the connection is in a terminal state and should be evicted.
+    /// </returns>
+    private static bool TryRouteToExistingConnection(
+        ConnectionInfo connInfo,
+        IPEndPoint ipEndPoint,
+        byte[] buffer,
+        int numReceived,
+        CancellationToken cancellationToken
+    ) {
+        lock (connInfo.SyncRoot) {
+            // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
+            switch (connInfo.State) {
+                case ConnectionState.Handshaking:
+                    // Enqueue failure means the transport is gone -> signal eviction.
+                    if (connInfo.DatagramTransport.TryEnqueueReceivedData(
+                            buffer, numReceived, cancellationToken,
+                            $"ProcessReceivedPacket(handshaking, endpoint={ipEndPoint})"
+                        ))
+                        return true;
+
+                    Logger.Warn($"Failed to enqueue datagram for handshaking connection {ipEndPoint}. Evicting.");
+                    return false;
+
+                case ConnectionState.Connected:
+                    if (!connInfo.DatagramTransport.TryEnqueueReceivedData(
+                            buffer, numReceived, cancellationToken,
+                            $"ProcessReceivedPacket(connected, endpoint={ipEndPoint})"
+                        ))
+                        Logger.Warn($"Failed to enqueue datagram for connected client {ipEndPoint}. Packet dropped.");
+
+                    // Enqueue failure on a connected client is non-fatal -> keep the connection.
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a new transport and connection entry for <paramref name="ipEndPoint"/> and spawns the handshake task.
+    /// Handles the race where another thread registered the same endpoint concurrently.
+    /// </summary>
+    private void StartNewConnection(
+        IPEndPoint ipEndPoint,
+        byte[] buffer,
+        int numReceived,
+        CancellationToken cancellationToken
+    ) {
+        Logger.Debug($"New endpoint {ipEndPoint} ({numReceived} bytes). Starting handshake.");
+
+        var transport = new ServerDatagramTransport(_socket!) { IPEndPoint = ipEndPoint };
         var newConnInfo = new ConnectionInfo {
-            DatagramTransport = newTransport,
+            DatagramTransport = transport,
             State = ConnectionState.Handshaking,
-
             Client = null
         };
 
-        if (_connections.TryAdd(ipEndPoint, newConnInfo)) {
-            try {
-                newTransport.ReceivedDataCollection.Add(new UdpDatagramTransport.ReceivedData {
-                    Buffer = buffer,
-                    Length = numReceived
-                }, cancellationToken);
-            } catch (Exception) {
-                _connections.TryRemove(ipEndPoint, out _);
-                newTransport.Dispose();
-                return;
-            }
+        if (!_connections.TryAdd(ipEndPoint, newConnInfo)) {
+            // Race: another thread registered this endpoint between our lookup and TryAdd.
+            transport.Dispose();
+            RouteToRaceWinner(ipEndPoint, buffer, numReceived, cancellationToken);
+            return;
+        }
 
-            // Spawn handshake task
-            Task.Factory.StartNew(
-                () => PerformHandshake(ipEndPoint, cancellationToken),
-                cancellationToken,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default
-            );
-        } else {
-            // Race condition: another thread added the connection while we were setting up
-            newTransport.Dispose();
+        if (!transport.TryEnqueueReceivedData(
+                buffer, numReceived, cancellationToken, $"ProcessReceivedPacket(new-connection, endpoint={ipEndPoint})"
+            )) {
+            Logger.Warn($"Failed to enqueue first datagram for new connection {ipEndPoint}. Aborting handshake.");
+            _connections.TryRemove(ipEndPoint, out _);
+            transport.Dispose();
+            return;
+        }
 
-            // Retry routing to the existing connection
-            if (_connections.TryGetValue(ipEndPoint, out var existingConnInfo)) {
-                lock (existingConnInfo) {
-                    if (existingConnInfo.State == ConnectionState.Handshaking) {
-                        try {
-                            existingConnInfo.DatagramTransport.ReceivedDataCollection.Add(
-                                new UdpDatagramTransport.ReceivedData {
-                                    Buffer = buffer,
-                                    Length = numReceived
-                                }, cancellationToken);
-                        } catch (Exception) {
-                            // Silently ignore
-                        }
-                    }
-                }
+        Task.Factory.StartNew(
+            () => PerformHandshake(ipEndPoint, cancellationToken),
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default
+        );
+    }
+
+    /// <summary>
+    /// After losing the TryAdd race, attempts to route the datagram to whichever connection won.
+    /// Packet loss here is acceptable since this is an extremely rare race and DTLS handles retransmission.
+    /// </summary>
+    private void RouteToRaceWinner(
+        IPEndPoint ipEndPoint,
+        byte[] buffer,
+        int numReceived,
+        CancellationToken cancellationToken
+    ) {
+        if (!_connections.TryGetValue(ipEndPoint, out var winner))
+            return;
+
+        lock (winner.SyncRoot) {
+            if (winner.State == ConnectionState.Handshaking) {
+                winner.DatagramTransport.TryEnqueueReceivedData(
+                    buffer, numReceived, cancellationToken,
+                    $"ProcessReceivedPacket(race-handshaking, endpoint={ipEndPoint})"
+                );
             }
         }
     }
@@ -408,7 +439,7 @@ internal class DtlsServer {
         }
 
         // Transition to connected state
-        lock (connInfo) {
+        lock (connInfo.SyncRoot) {
             if (connInfo.State != ConnectionState.Handshaking) {
                 Logger.Warn($"Connection {endPoint} no longer in handshaking state");
                 dtlsTransport.Close();
@@ -500,6 +531,11 @@ internal class DtlsServer {
     /// </summary>
     private class ConnectionInfo {
         /// <summary>
+        /// Private synchronization object for mutating connection state.
+        /// </summary>
+        public object SyncRoot { get; } = new();
+
+        /// <summary>
         /// The datagram transport for this connection.
         /// </summary>
         public required ServerDatagramTransport DatagramTransport { get; init; }
@@ -520,3 +556,4 @@ internal class DtlsServer {
         public Thread? ReceiveThread { get; set; }
     }
 }
+

--- a/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
+++ b/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
@@ -16,78 +16,61 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     
     /// <summary>
-    /// A thread-safe blocking collection storing received data that is used to handle the "Receive" calls from the
-    /// DTLS transport.
+    /// A thread-safe queue of complete UDP datagrams handed off from the socket receive loop to DTLS.
+    /// Each entry represents exactly one received datagram and must never be treated as a stream fragment.
     /// </summary>
     public BlockingCollection<ReceivedData> ReceivedDataCollection { get; } = new();
 
     /// <summary>
-    /// This method is called whenever the corresponding DtlsTransport's Receive is called. The implementation
-    /// obtains data from the blocking collection and store it in the given buffer. If no data is present in the
-    /// collection within the given <paramref name="waitMillis"/>, the method returns -1.
+    /// Called by the DTLS stack to dequeue a single datagram and copy it into <paramref name="buf"/>.
+    /// If no datagram is available within <paramref name="waitMillis"/>, or if the transport is shutting down,
+    /// the method returns <c>-1</c>.
+    /// <para><b>Contract:</b></para>
+    /// <list type="bullet">
+    ///   <item><description>Each <see cref="ReceivedData"/> entry is one full UDP datagram.</description></item>
+    ///   <item><description>Callers must pass a buffer of at least <see cref="GetReceiveLimit"/> bytes.</description></item>
+    ///   <item><description>Producers must enqueue datagrams no larger than <see cref="GetReceiveLimit"/>.</description></item>
+    /// </list>
+    /// <para><b>Edge case behavior:</b></para>
+    /// <list type="bullet">
+    ///   <item><description>If <paramref name="len"/> is smaller than the queued datagram, only the fitting prefix is copied.</description></item>
+    ///   <item><description>The remaining bytes are silently discarded — not re-queued.</description></item>
+    /// </list>
+    /// <para>
+    /// Discard is intentional: UDP/DTLS has datagram semantics, not stream semantics. Re-queuing a tail would
+    /// splice it into the next read and corrupt the receive flow. In normal operation this branch is never hit,
+    /// because outbound packets are fragmented below 1200 bytes to leave headroom for DTLS overhead under the
+    /// cap defined by <see cref="Networking.Client.DtlsClient.MaxPacketSize"/>.
+    /// </para>
     /// </summary>
-    /// <param name="buf">Byte array to store the received data.</param>
-    /// <param name="off">The offset at which to begin storing the data.</param>
-    /// <param name="len">The number of bytes that can be stored in the buffer.</param>
-    /// <param name="waitMillis">The number of milliseconds to wait for data to fill.</param>
-    /// <returns>The number of bytes that were received, or -1 if no bytes were received in the given time.</returns>
-    public int Receive(byte[] buf, int off, int len, int waitMillis) {
-        if (_cancellationTokenSource.IsCancellationRequested) {
+    /// <param name="buf">Destination buffer for the received datagram bytes.</param>
+    /// <param name="off">Offset within <paramref name="buf"/> at which to begin writing.</param>
+    /// <param name="len">Usable capacity of <paramref name="buf"/> starting at <paramref name="off"/>.</param>
+    /// <param name="waitMillis">Milliseconds to block waiting for a datagram before timing out.</param>
+    /// <returns>
+    /// Bytes copied into <paramref name="buf"/>, or <c>-1</c> if the wait timed out or the transport
+    /// was canceled/disposed.
+    /// </returns>
+    public int Receive(byte[] buf, int off, int len, int waitMillis)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
             return -1;
+
+        try
+        {
+            if (!ReceivedDataCollection.TryTake(out var data, waitMillis, _cancellationTokenSource.Token))
+                return -1;
+
+            // Clamp to available buffer space and drop any excess. Re-queuing the remainder would turn a datagram
+            // transport into a fake byte stream and corrupt the next DTLS read.
+            var bytesToCopy = System.Math.Min(data.Length, len);
+            Array.Copy(data.Buffer, 0, buf, off, bytesToCopy);
+            return bytesToCopy;
         }
-
-        bool tryTakeSuccess;
-        ReceivedData data;
-        
-        try {
-            tryTakeSuccess = ReceivedDataCollection.TryTake(out data, waitMillis, _cancellationTokenSource.Token);
-        } catch (OperationCanceledException) {
-            return -1;
-        } catch (ArgumentNullException) {
-            // Mono bug: BlockingCollection can throw ArgumentNullException instead of ObjectDisposedException
-            // when disposed during TryTake
-            return -1;
-        } catch (ObjectDisposedException) {
-            return -1;
-        }
-
-        if (!tryTakeSuccess) {
-            return -1;
-        }
-
-        // If there is more data in the entry we received from the blocking collection than space in the buffer
-        // from the method, we need to add as much data into the buffer and put the rest back in the collection
-        if (len < data.Length) {
-            // Fill the buffer from the method with as much data from the entry as possible
-            for (var i = off; i < off + len; i++) {
-                buf[i] = data.Buffer[i - off];
-            }
-
-            // Calculate the length of the leftover buffer and instantiate it
-            var leftoverLength = data.Length - len;
-            var leftoverBuffer = new byte[leftoverLength];
-
-            // Fill the leftover buffer with the leftover data from the entry
-            for (var i = 0; i < leftoverLength; i++) {
-                leftoverBuffer[i] = data.Buffer[len + i];
-            }
-
-            // Add the leftover buffer and its length back to the collection
-            ReceivedDataCollection.Add(new ReceivedData {
-                Buffer = leftoverBuffer,
-                Length = leftoverLength
-            });
-
-            return len;
-        }
-
-        // In this case, the space in the buffer from the method is large enough, so we fill it with all the data
-        // from the collection entry
-        for (var i = 0; i < data.Length; i++) {
-            buf[off + i] = data.Buffer[i];
-        }
-
-        return data.Length;
+        catch (OperationCanceledException)  { return -1; }
+        /* Mono bug: BlockingCollection can throw ArgumentNullException instead of ObjectDisposedException when disposed during TryTake. */
+        catch (ArgumentNullException)       { return -1; }
+        catch (ObjectDisposedException)     { return -1; }
     }
     
     /// <summary>
@@ -126,8 +109,9 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     }
     
     /// <summary>
-    /// Data class containing a buffer and the corresponding length of bytes stored in that buffer. Not necessarily
-    /// the length of the buffer.
+    /// One received UDP datagram.
+    /// <see cref="Length"/> may be smaller than <see cref="Buffer"/>.Length, but it must never describe bytes from
+    /// more than one datagram.
     /// </summary>
     public class ReceivedData {
         /// <summary>

--- a/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
+++ b/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
@@ -21,7 +21,7 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     /// Cached fully qualified type name used in diagnostics so logging does not repeatedly resolve it via reflection.
     /// </summary>
     private const string TypeName = nameof(UdpEncryptedTransport);
-    
+
     /// <summary>
     /// A thread-safe queue of complete UDP datagrams handed off from the socket receive loop to DTLS.
     /// Each entry represents exactly one received datagram and must never be treated as a stream fragment.
@@ -55,16 +55,14 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     /// <param name="len">Usable capacity of <paramref name="buf"/> starting at <paramref name="off"/>.</param>
     /// <param name="waitMillis">Milliseconds to block waiting for a datagram before timing out.</param>
     /// <returns>
-    /// Bytes copied into <paramref name="buf"/>, or <c>-1</c> if the wait timed out or the transport
+    /// Number of bytes copied into <paramref name="buf"/>, or <c>-1</c> if the wait timed out or the transport
     /// was canceled/disposed.
     /// </returns>
-    public int Receive(byte[] buf, int off, int len, int waitMillis)
-    {
+    public int Receive(byte[] buf, int off, int len, int waitMillis) {
         if (_cancellationTokenSource.IsCancellationRequested)
             return -1;
 
-        try
-        {
+        try {
             if (!ReceivedDataCollection.TryTake(out var data, waitMillis, _cancellationTokenSource.Token))
                 return -1;
 
@@ -83,11 +81,15 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
             var bytesToCopy = System.Math.Min(data.Length, len);
             Array.Copy(data.Buffer, 0, buf, off, bytesToCopy);
             return bytesToCopy;
+        } catch (OperationCanceledException) {
+            return -1;
+        } catch (ArgumentNullException) {
+            // Mono bug: BlockingCollection can throw ArgumentNullException instead of ObjectDisposedException
+            // when disposed during TryTake
+            return -1;
+        } catch (ObjectDisposedException) {
+            return -1;
         }
-        catch (OperationCanceledException)  { return -1; }
-        /* Mono bug: BlockingCollection can throw ArgumentNullException instead of ObjectDisposedException when disposed during TryTake. */
-        catch (ArgumentNullException)       { return -1; }
-        catch (ObjectDisposedException)     { return -1; }
     }
 
     /// <summary>
@@ -99,12 +101,15 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     /// <param name="cancellationToken">Cancellation token for the enqueue operation.</param>
     /// <param name="source">Human-readable source context for diagnostics.</param>
     /// <returns><see langword="true"/> if the datagram was enqueued; otherwise <see langword="false"/>.</returns>
-    public bool TryEnqueueReceivedData(byte[] buffer, int length, CancellationToken cancellationToken, [CallerMemberName] string source = "")
-    {
-        // Unigned cast collapses the negative-length and exceeds-buffer checks into one branch.
+    public bool TryEnqueueReceivedData(
+        byte[] buffer, 
+        int length, 
+        CancellationToken cancellationToken, 
+        [CallerMemberName] string source = ""
+    ) {
+        // Unsigned cast collapses the negative-length and exceeds-buffer checks into one branch.
         // A negative length wraps to a large uint, which is always bigger than the buffer.Length.
-        if ((uint)length > (uint)buffer.Length)
-        {
+        if ((uint) length > (uint) buffer.Length) {
             Logger.Error(
                 $"Refusing to enqueue datagram with invalid length in {TypeName}. " +
                 $"source={source}, length={length}, bufferLength={buffer.Length}"
@@ -113,8 +118,7 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
         }
 
         var receiveLimit = GetReceiveLimit();
-        if (length > receiveLimit)
-        {
+        if (length > receiveLimit) {
             Logger.Error(
                 $"Refusing to enqueue datagram larger than receive limit in {TypeName}. " +
                 $"source={source}, length={length}, receiveLimit={receiveLimit}"
@@ -122,15 +126,16 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
             return false;
         }
 
-        try
-        {
+        try {
             ReceivedDataCollection.Add(new ReceivedData { Buffer = buffer, Length = length }, cancellationToken);
             return true;
+        } catch (OperationCanceledException) {
+            return false;
+        } catch (InvalidOperationException) {
+            return false;
         }
-        catch (OperationCanceledException) { return false; }
-        catch (InvalidOperationException)  { return false; }
     }
-    
+
     /// <summary>
     /// The maximum number of bytes to receive in a single call to <see cref="Receive"/>.
     /// </summary>

--- a/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
+++ b/SSMP/Networking/Transport/UDP/UdpDatagramTransport.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Org.BouncyCastle.Tls;
+using SSMP.Logging;
 
 namespace SSMP.Networking.Transport.UDP;
 
@@ -16,10 +18,15 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     
     /// <summary>
+    /// Cached fully qualified type name used in diagnostics so logging does not repeatedly resolve it via reflection.
+    /// </summary>
+    private const string TypeName = nameof(UdpEncryptedTransport);
+    
+    /// <summary>
     /// A thread-safe queue of complete UDP datagrams handed off from the socket receive loop to DTLS.
     /// Each entry represents exactly one received datagram and must never be treated as a stream fragment.
     /// </summary>
-    public BlockingCollection<ReceivedData> ReceivedDataCollection { get; } = new();
+    private BlockingCollection<ReceivedData> ReceivedDataCollection { get; } = new();
 
     /// <summary>
     /// Called by the DTLS stack to dequeue a single datagram and copy it into <paramref name="buf"/>.
@@ -34,7 +41,7 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
     /// <para><b>Edge case behavior:</b></para>
     /// <list type="bullet">
     ///   <item><description>If <paramref name="len"/> is smaller than the queued datagram, only the fitting prefix is copied.</description></item>
-    ///   <item><description>The remaining bytes are silently discarded — not re-queued.</description></item>
+    ///   <item><description>The remaining bytes are discarded and logged loudly and not re-queued.</description></item>
     /// </list>
     /// <para>
     /// Discard is intentional: UDP/DTLS has datagram semantics, not stream semantics. Re-queuing a tail would
@@ -61,6 +68,16 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
             if (!ReceivedDataCollection.TryTake(out var data, waitMillis, _cancellationTokenSource.Token))
                 return -1;
 
+            if (data.Length > len) {
+                Logger.Error(
+                    $"DTLS receive buffer smaller than queued datagram in {GetType().FullName}. " +
+                    $"Truncating datagram to preserve UDP semantics. packetLength={data.Length}, " +
+                    $"availableLength={len}, bufferLength={buf.Length}, offset={off}, " +
+                    $"receiveLimit={GetReceiveLimit()}, sendLimit={GetSendLimit()}, " +
+                    $"threadId={Environment.CurrentManagedThreadId}"
+                );
+            }
+
             // Clamp to available buffer space and drop any excess. Re-queuing the remainder would turn a datagram
             // transport into a fake byte stream and corrupt the next DTLS read.
             var bytesToCopy = System.Math.Min(data.Length, len);
@@ -71,6 +88,47 @@ internal abstract class UdpDatagramTransport : DatagramTransport {
         /* Mono bug: BlockingCollection can throw ArgumentNullException instead of ObjectDisposedException when disposed during TryTake. */
         catch (ArgumentNullException)       { return -1; }
         catch (ObjectDisposedException)     { return -1; }
+    }
+
+    /// <summary>
+    /// Validates and enqueues one complete received datagram for later DTLS consumption.
+    /// This is the producer-side choke point for enforcing the receive contract.
+    /// </summary>
+    /// <param name="buffer">Backing buffer containing the datagram bytes.</param>
+    /// <param name="length">Number of valid bytes in <paramref name="buffer"/>.</param>
+    /// <param name="cancellationToken">Cancellation token for the enqueue operation.</param>
+    /// <param name="source">Human-readable source context for diagnostics.</param>
+    /// <returns><see langword="true"/> if the datagram was enqueued; otherwise <see langword="false"/>.</returns>
+    public bool TryEnqueueReceivedData(byte[] buffer, int length, CancellationToken cancellationToken, [CallerMemberName] string source = "")
+    {
+        // Unigned cast collapses the negative-length and exceeds-buffer checks into one branch.
+        // A negative length wraps to a large uint, which is always bigger than the buffer.Length.
+        if ((uint)length > (uint)buffer.Length)
+        {
+            Logger.Error(
+                $"Refusing to enqueue datagram with invalid length in {TypeName}. " +
+                $"source={source}, length={length}, bufferLength={buffer.Length}"
+            );
+            return false;
+        }
+
+        var receiveLimit = GetReceiveLimit();
+        if (length > receiveLimit)
+        {
+            Logger.Error(
+                $"Refusing to enqueue datagram larger than receive limit in {TypeName}. " +
+                $"source={source}, length={length}, receiveLimit={receiveLimit}"
+            );
+            return false;
+        }
+
+        try
+        {
+            ReceivedDataCollection.Add(new ReceivedData { Buffer = buffer, Length = length }, cancellationToken);
+            return true;
+        }
+        catch (OperationCanceledException) { return false; }
+        catch (InvalidOperationException)  { return false; }
     }
     
     /// <summary>


### PR DESCRIPTION
## Summary

This PR hardens the DTLS receive path and cleans up the server-side connection lifecycle around it.

The main goal is to make the UDP/DTLS contract explicit and enforced in the right place:
- queued items must represent complete datagrams, not stream fragments
- producer-side code must not enqueue invalid or oversized datagrams
- the DTLS receive path must never re-queue leftover bytes from a partially consumed datagram

## Why

The previous transport code relied on an implicit invariant spread across multiple files:
- DTLS client/server max packet size is `1400`
- UDP datagram transport receive limit is aligned to that size
- application-level fragmentation already happens earlier at `1200`, leaving headroom for DTLS overhead

That means the “oversized queued datagram” path should be unreachable in normal operation. Even so, the code needed to be explicit about the contract and fail safely if it is ever violated.

## What changed

### UDP datagram transport

- Expanded the XML documentation on `UdpDatagramTransport.Receive(...)` to describe the actual datagram contract and edge-case behavior.
- Made `ReceivedDataCollection` private so callers cannot bypass validation.
- Added `TryEnqueueReceivedData(...)` as the producer-side choke point for validating and enqueueing received datagrams.
- Added loud logging if `Receive(...)` ever has to truncate because the queued datagram is larger than the DTLS-provided writable window.
- Kept truncation behavior datagram-safe: excess bytes are dropped, never re-queued.

### Client receive path

- Reworked `DtlsClient.SocketReceiveLoop(...)` so startup preconditions are checked once before entering the loop.
- Switched the temporary socket receive buffer to `ArrayPool<byte>` to avoid fixed-size per-iteration allocations.
- Kept the explicit copy into a dedicated per-packet array before enqueueing, because BouncyCastle’s buffer ownership/lifetime expectations are not explicit enough to safely reuse buffers across that boundary.
- Routed client enqueueing through `TryEnqueueReceivedData(...)`.

### Server receive path

- Refactored server packet routing into smaller units:
  - `ProcessReceivedPacket(...)`
  - `TryRouteToExistingConnection(...)`
  - `StartNewConnection(...)`
  - `RouteToRaceWinner(...)`
- Clarified behavior for existing connections:
  - enqueue failure during handshaking is treated as fatal and causes eviction
  - enqueue failure for connected clients drops the packet but keeps the connection
- Routed all server enqueue operations through `TryEnqueueReceivedData(...)`.
- Made the TryAdd race path explicit and documented why rare packet loss there is acceptable.

### Locking cleanup

- Replaced `lock (connInfo)` with a dedicated `connInfo.SyncRoot`.
- This avoids synchronizing on the `ConnectionInfo` instance itself and makes the lock target private and intentional.
- All remaining `lock (connInfo)` sites were migrated so the file no longer mixes lock objects for the same state.