### PR TITLE
feat: Fix matchmaking endpoint and host refresh races

### DIFF
--- a/MMS/Models/Matchmaking/JoinSession.cs
+++ b/MMS/Models/Matchmaking/JoinSession.cs
@@ -22,11 +22,6 @@ public sealed class JoinSession {
     public required string ClientIp { get; init; }
 
     /// <summary>
-    /// Public IP address observed from the client's UDP discovery packet, if available.
-    /// </summary>
-    public string? ClientDiscoveredIp { get; set; }
-
-    /// <summary>
     /// Client discovery token used to map the external port.
     /// </summary>
     public required string ClientDiscoveryToken { get; init; }

--- a/MMS/Models/Matchmaking/JoinSession.cs
+++ b/MMS/Models/Matchmaking/JoinSession.cs
@@ -22,6 +22,11 @@ public sealed class JoinSession {
     public required string ClientIp { get; init; }
 
     /// <summary>
+    /// Public IP address observed from the client's UDP discovery packet, if available.
+    /// </summary>
+    public string? ClientDiscoveredIp { get; set; }
+
+    /// <summary>
     /// Client discovery token used to map the external port.
     /// </summary>
     public required string ClientDiscoveryToken { get; init; }
@@ -30,6 +35,11 @@ public sealed class JoinSession {
     /// Externally visible client port once discovery completes.
     /// </summary>
     public int? ClientExternalPort { get; set; }
+
+    /// <summary>
+    /// Indicates that the join is waiting for a fresh host mapping after requesting a host refresh.
+    /// </summary>
+    public bool AwaitingHostRefresh { get; set; }
 
     /// <summary>
     /// The client WebSocket attached to this join attempt, if connected.

--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -291,18 +291,29 @@ public sealed class JoinSessionCoordinator {
 
     /// <summary>
     /// Handles a UDP port discovery event originating from the client side.
-    /// Records the client's external endpoint, requests a host refresh, and attempts to start punching.
+    /// Records the client's external port, requests a host refresh, and attempts to start punching.
     /// </summary>
     private async Task HandleClientPortDiscoveredAsync(
         string joinId,
-        string clientIp,
+        string discoveredClientIp,
         int port,
         CancellationToken cancellationToken
     ) {
         var session = GetJoinSession(joinId);
         if (session == null) return;
 
-        session.ClientDiscoveredIp = clientIp;
+        if (!string.Equals(session.ClientIp, discoveredClientIp, StringComparison.Ordinal)) {
+            _logger.LogWarning(
+                "Client path mismatch for join {JoinId}: HTTPS join used {JoinIp}, UDP discovery used {DiscoveryIp}:{DiscoveryPort}",
+                joinId,
+                session.ClientIp,
+                discoveredClientIp,
+                port
+            );
+            await FailJoinSessionAsync(joinId, "client_path_mismatch", cancellationToken);
+            return;
+        }
+
         session.ClientExternalPort = port;
         session.AwaitingHostRefresh = true;
         await JoinSessionMessenger.SendClientMappingReceivedAsync(session, port, cancellationToken);
@@ -376,7 +387,7 @@ public sealed class JoinSessionCoordinator {
             var hostSent = await JoinSessionMessenger.SendStartPunchToHostAsync(
                 lobby,
                 joinId,
-                session.ClientDiscoveredIp ?? session.ClientIp,
+                session.ClientIp,
                 session.ClientExternalPort.Value,
                 lobby.ExternalPort.Value,
                 startTimeMs,

--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.WebSockets;
 using MMS.Models;
 using MMS.Models.Lobbies;
@@ -113,42 +112,29 @@ public sealed class JoinSessionCoordinator {
     }
 
     /// <summary>
-    /// Records the externally observed UDP endpoint for a discovery token and advances the punch flow.
+    /// Records the externally observed UDP port for a discovery token and advances the punch flow.
     /// </summary>
     /// <remarks>
     /// The token determines whether this is a host or client port discovery event and
     /// dispatches to the appropriate handler.
     /// </remarks>
     /// <param name="token">The discovery token included in the UDP packet.</param>
-    /// <param name="remoteEndPoint">The external UDP endpoint observed by the server.</param>
+    /// <param name="port">The external port observed by the server.</param>
     /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
-    public async Task SetDiscoveredPortAsync(
-        string token,
-        IPEndPoint remoteEndPoint,
-        CancellationToken cancellationToken = default
-    ) {
+    public async Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) {
         if (!_store.TryGetDiscoveryMetadata(token, out var metadata) || metadata == null)
             return;
 
-        if (!_store.TrySetDiscoveredPort(token, remoteEndPoint.Port))
+        if (!_store.TrySetDiscoveredPort(token, port))
             return;
 
         if (metadata.HostConnectionData != null) {
-            await HandleHostPortDiscoveredAsync(
-                metadata.HostConnectionData,
-                remoteEndPoint.Port,
-                cancellationToken
-            );
+            await HandleHostPortDiscoveredAsync(metadata.HostConnectionData, port, cancellationToken);
             return;
         }
 
         if (metadata.JoinId != null) {
-            await HandleClientPortDiscoveredAsync(
-                metadata.JoinId,
-                remoteEndPoint.Address.ToString(),
-                remoteEndPoint.Port,
-                cancellationToken
-            );
+            await HandleClientPortDiscoveredAsync(metadata.JoinId, port, cancellationToken);
         }
     }
 
@@ -295,24 +281,11 @@ public sealed class JoinSessionCoordinator {
     /// </summary>
     private async Task HandleClientPortDiscoveredAsync(
         string joinId,
-        string discoveredClientIp,
         int port,
         CancellationToken cancellationToken
     ) {
         var session = GetJoinSession(joinId);
         if (session == null) return;
-
-        if (!string.Equals(session.ClientIp, discoveredClientIp, StringComparison.Ordinal)) {
-            _logger.LogWarning(
-                "Client path mismatch for join {JoinId}: HTTPS join used {JoinIp}, UDP discovery used {DiscoveryIp}:{DiscoveryPort}",
-                joinId,
-                session.ClientIp,
-                discoveredClientIp,
-                port
-            );
-            await FailJoinSessionAsync(joinId, "client_path_mismatch", cancellationToken);
-            return;
-        }
 
         session.ClientExternalPort = port;
         session.AwaitingHostRefresh = true;

--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -139,6 +139,44 @@ public sealed class JoinSessionCoordinator {
     }
 
     /// <summary>
+    /// Validates that a client discovery packet arrived from the same IP address that created the join session.
+    /// Host discovery packets are ignored by this check.
+    /// </summary>
+    /// <param name="token">The discovery token included in the UDP packet.</param>
+    /// <param name="clientIp">The IP address observed for the UDP packet.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    /// <returns>
+    /// <see langword="true"/> when discovery processing may continue; otherwise <see langword="false"/>.
+    /// </returns>
+    public async Task<bool> ValidateDiscoveredClientIpAsync(
+        string token,
+        string clientIp,
+        CancellationToken cancellationToken = default
+    ) {
+        if (!_store.TryGetDiscoveryMetadata(token, out var metadata) || metadata == null)
+            return false;
+
+        if (metadata.JoinId == null)
+            return true;
+
+        var session = GetJoinSession(metadata.JoinId);
+        if (session == null)
+            return false;
+
+        if (string.Equals(session.ClientIp, clientIp, StringComparison.Ordinal))
+            return true;
+
+        _logger.LogWarning(
+            "Client path mismatch for join {JoinId}: HTTPS join used {JoinIp}, UDP discovery used {DiscoveryIp}",
+            metadata.JoinId,
+            session.ClientIp,
+            clientIp
+        );
+        await FailJoinSessionAsync(metadata.JoinId, "client_path_mismatch", cancellationToken);
+        return false;
+    }
+
+    /// <summary>
     /// Returns the externally observed UDP port for a discovery token, or
     /// <see langword="null"/> if the port has not yet been recorded.
     /// </summary>

--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.WebSockets;
 using MMS.Models;
 using MMS.Models.Lobbies;
@@ -112,29 +113,43 @@ public sealed class JoinSessionCoordinator {
     }
 
     /// <summary>
-    /// Records the externally observed UDP port for a discovery token and advances the punch flow.
+    /// Records the externally observed UDP endpoint for a discovery token and advances the punch flow.
     /// </summary>
     /// <remarks>
     /// The token determines whether this is a host or client port discovery event and
     /// dispatches to the appropriate handler.
     /// </remarks>
     /// <param name="token">The discovery token included in the UDP packet.</param>
-    /// <param name="port">The external port observed by the server.</param>
+    /// <param name="remoteEndPoint">The external UDP endpoint observed by the server.</param>
     /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
-    public async Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) {
+    public async Task SetDiscoveredPortAsync(
+        string token,
+        IPEndPoint remoteEndPoint,
+        CancellationToken cancellationToken = default
+    ) {
         if (!_store.TryGetDiscoveryMetadata(token, out var metadata) || metadata == null)
             return;
 
-        if (!_store.TrySetDiscoveredPort(token, port))
+        if (!_store.TrySetDiscoveredPort(token, remoteEndPoint.Port))
             return;
 
         if (metadata.HostConnectionData != null) {
-            await HandleHostPortDiscoveredAsync(metadata.HostConnectionData, port, cancellationToken);
+            await HandleHostPortDiscoveredAsync(
+                metadata.HostConnectionData,
+                remoteEndPoint.Port,
+                cancellationToken
+            );
             return;
         }
 
-        if (metadata.JoinId != null)
-            await HandleClientPortDiscoveredAsync(metadata.JoinId, port, cancellationToken);
+        if (metadata.JoinId != null) {
+            await HandleClientPortDiscoveredAsync(
+                metadata.JoinId,
+                remoteEndPoint.Address.ToString(),
+                remoteEndPoint.Port,
+                cancellationToken
+            );
+        }
     }
 
     /// <summary>
@@ -262,23 +277,34 @@ public sealed class JoinSessionCoordinator {
         if (lobby == null) return;
 
         lobby.ExternalPort = port;
+
+        foreach (var joinId in _store.GetJoinIdsForLobby(lobbyConnectionData)) {
+            var session = GetJoinSession(joinId);
+            if (session != null) {
+                session.AwaitingHostRefresh = false;
+            }
+        }
+
         await JoinSessionMessenger.SendHostMappingReceivedAsync(lobby, port, cancellationToken);
         await TryStartPendingJoinSessionsAsync(lobbyConnectionData, cancellationToken);
     }
 
     /// <summary>
     /// Handles a UDP port discovery event originating from the client side.
-    /// Records the client's external port, requests a host refresh, and attempts to start punching.
+    /// Records the client's external endpoint, requests a host refresh, and attempts to start punching.
     /// </summary>
     private async Task HandleClientPortDiscoveredAsync(
         string joinId,
+        string clientIp,
         int port,
         CancellationToken cancellationToken
     ) {
         var session = GetJoinSession(joinId);
         if (session == null) return;
 
+        session.ClientDiscoveredIp = clientIp;
         session.ClientExternalPort = port;
+        session.AwaitingHostRefresh = true;
         await JoinSessionMessenger.SendClientMappingReceivedAsync(session, port, cancellationToken);
 
         var hostRefreshed = await _messenger.SendHostRefreshRequestAsync(
@@ -318,6 +344,8 @@ public sealed class JoinSessionCoordinator {
         var session = GetJoinSession(joinId);
         if (session?.ClientExternalPort == null) return;
 
+        if (session.AwaitingHostRefresh) return;
+
         var lobby = _lobbyService.GetLobby(session.LobbyConnectionData);
         if (lobby == null) {
             await FailJoinSessionAsync(joinId, "lobby_closed", cancellationToken);
@@ -348,7 +376,7 @@ public sealed class JoinSessionCoordinator {
             var hostSent = await JoinSessionMessenger.SendStartPunchToHostAsync(
                 lobby,
                 joinId,
-                session.ClientIp,
+                session.ClientDiscoveredIp ?? session.ClientIp,
                 session.ClientExternalPort.Value,
                 lobby.ExternalPort.Value,
                 startTimeMs,

--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -153,7 +153,7 @@ public sealed class JoinSessionCoordinator {
         string clientIp,
         CancellationToken cancellationToken = default
     ) {
-        if (!_store.TryGetDiscoveryMetadata(token, out var metadata) || metadata == null)
+        if (!_store.TryGetDiscoveryMetadata(token, out var metadata))
             return false;
 
         if (metadata.JoinId == null)

--- a/MMS/Services/Matchmaking/JoinSessionService.cs
+++ b/MMS/Services/Matchmaking/JoinSessionService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.WebSockets;
 using MMS.Models.Lobbies;
 using MMS.Models.Matchmaking;
@@ -49,9 +50,12 @@ public class JoinSessionService {
     public bool AttachJoinWebSocket(string joinId, WebSocket webSocket) =>
         _coordinator.AttachJoinWebSocket(joinId, webSocket);
 
-    /// <summary>Records the externally observed UDP port for a discovery token and advances the punch flow.</summary>
-    public Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) =>
-        _coordinator.SetDiscoveredPortAsync(token, port, cancellationToken);
+    /// <summary>Records the externally observed UDP endpoint for a discovery token and advances the punch flow.</summary>
+    public Task SetDiscoveredPortAsync(
+        string token,
+        IPEndPoint remoteEndPoint,
+        CancellationToken cancellationToken = default
+    ) => _coordinator.SetDiscoveredPortAsync(token, remoteEndPoint, cancellationToken);
 
     /// <summary>Returns the externally observed UDP port for a discovery token, or <see langword="null"/> if not yet recorded.</summary>
     public int? GetDiscoveredPort(string token) =>

--- a/MMS/Services/Matchmaking/JoinSessionService.cs
+++ b/MMS/Services/Matchmaking/JoinSessionService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.WebSockets;
 using MMS.Models.Lobbies;
 using MMS.Models.Matchmaking;
@@ -50,12 +49,9 @@ public class JoinSessionService {
     public bool AttachJoinWebSocket(string joinId, WebSocket webSocket) =>
         _coordinator.AttachJoinWebSocket(joinId, webSocket);
 
-    /// <summary>Records the externally observed UDP endpoint for a discovery token and advances the punch flow.</summary>
-    public Task SetDiscoveredPortAsync(
-        string token,
-        IPEndPoint remoteEndPoint,
-        CancellationToken cancellationToken = default
-    ) => _coordinator.SetDiscoveredPortAsync(token, remoteEndPoint, cancellationToken);
+    /// <summary>Records the externally observed UDP port for a discovery token and advances the punch flow.</summary>
+    public Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) =>
+        _coordinator.SetDiscoveredPortAsync(token, port, cancellationToken);
 
     /// <summary>Returns the externally observed UDP port for a discovery token, or <see langword="null"/> if not yet recorded.</summary>
     public int? GetDiscoveredPort(string token) =>

--- a/MMS/Services/Matchmaking/JoinSessionService.cs
+++ b/MMS/Services/Matchmaking/JoinSessionService.cs
@@ -53,6 +53,13 @@ public class JoinSessionService {
     public Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) =>
         _coordinator.SetDiscoveredPortAsync(token, port, cancellationToken);
 
+    /// <summary>Validates that a client discovery packet arrived from the expected join IP.</summary>
+    public Task<bool> ValidateDiscoveredClientIpAsync(
+        string token,
+        string clientIp,
+        CancellationToken cancellationToken = default
+    ) => _coordinator.ValidateDiscoveredClientIpAsync(token, clientIp, cancellationToken);
+
     /// <summary>Returns the externally observed UDP port for a discovery token, or <see langword="null"/> if not yet recorded.</summary>
     public int? GetDiscoveredPort(string token) =>
         _coordinator.GetDiscoveredPort(token);

--- a/MMS/Services/Matchmaking/JoinSessionStore.cs
+++ b/MMS/Services/Matchmaking/JoinSessionStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using MMS.Models.Matchmaking;
 
 namespace MMS.Services.Matchmaking;
@@ -87,7 +88,7 @@ public sealed class JoinSessionStore {
     public bool ContainsDiscoveryToken(string token) => _discoveryMetadata.ContainsKey(token);
 
     /// <summary>Attempts to retrieve the metadata for a discovery token.</summary>
-    public bool TryGetDiscoveryMetadata(string token, out DiscoveryTokenMetadata? metadata) {
+    public bool TryGetDiscoveryMetadata(string token, [NotNullWhen(true)] out DiscoveryTokenMetadata? metadata) {
         if (!_discoveryMetadata.TryGetValue(token, out var stored)) {
             metadata = null;
             return false;

--- a/MMS/Services/Network/UdpDiscoveryService.cs
+++ b/MMS/Services/Network/UdpDiscoveryService.cs
@@ -98,7 +98,7 @@ public sealed class UdpDiscoveryService : BackgroundService {
             PrivacyFormatter.Format(remoteEndPoint)
         );
 
-        await _joinSessionService.SetDiscoveredPortAsync(token, remoteEndPoint, cancellationToken);
+        await _joinSessionService.SetDiscoveredPortAsync(token, remoteEndPoint.Port, cancellationToken);
     }
 
     /// <summary>

--- a/MMS/Services/Network/UdpDiscoveryService.cs
+++ b/MMS/Services/Network/UdpDiscoveryService.cs
@@ -98,6 +98,13 @@ public sealed class UdpDiscoveryService : BackgroundService {
             PrivacyFormatter.Format(remoteEndPoint)
         );
 
+        if (!await _joinSessionService.ValidateDiscoveredClientIpAsync(
+                token,
+                remoteEndPoint.Address.ToString(),
+                cancellationToken
+            ))
+            return;
+
         await _joinSessionService.SetDiscoveredPortAsync(token, remoteEndPoint.Port, cancellationToken);
     }
 

--- a/MMS/Services/Network/UdpDiscoveryService.cs
+++ b/MMS/Services/Network/UdpDiscoveryService.cs
@@ -98,7 +98,7 @@ public sealed class UdpDiscoveryService : BackgroundService {
             PrivacyFormatter.Format(remoteEndPoint)
         );
 
-        await _joinSessionService.SetDiscoveredPortAsync(token, remoteEndPoint.Port, cancellationToken);
+        await _joinSessionService.SetDiscoveredPortAsync(token, remoteEndPoint, cancellationToken);
     }
 
     /// <summary>

--- a/SSMP/Networking/Matchmaking/MmsClient.cs
+++ b/SSMP/Networking/Matchmaking/MmsClient.cs
@@ -22,6 +22,9 @@ internal sealed class MmsClient {
     /// <summary>Last error from most recent operation.</summary>
     public MatchmakingError LastMatchmakingError { get; private set; } = MatchmakingError.None;
 
+    /// <summary>Last machine-readable join failure reason returned by MMS.</summary>
+    public string? LastJoinFailureReason { get; private set; }
+
     public MmsClient(
         string baseUrl,
         int discoveryPort,
@@ -128,8 +131,9 @@ internal sealed class MmsClient {
     /// Signals a join failure with a specific reason.
     /// </summary>
     private void SetJoinFailed(string reason) {
-        Logger.Warn($"MmsClient: matchmaking join failed – {reason}");
+        Logger.Warn($"MmsClient: matchmaking join failed - {reason}");
         LastMatchmakingError = MatchmakingError.JoinFailed;
+        LastJoinFailureReason = reason;
     }
 
     /// <summary>
@@ -137,5 +141,6 @@ internal sealed class MmsClient {
     /// </summary>
     private void ClearErrors() {
         LastMatchmakingError = MatchmakingError.None;
+        LastJoinFailureReason = null;
     }
 }

--- a/SSMP/Ui/ConnectInterface.cs
+++ b/SSMP/Ui/ConnectInterface.cs
@@ -336,6 +336,13 @@ internal class ConnectInterface {
     private const string ErrorUnknown = "Failed to connect:\nUnknown reason";
 
     /// <summary>
+    /// Warning shown when matchmaking HTTP traffic and UDP discovery use different network paths.
+    /// </summary>
+    private const string ErrorSplitTunnelDetected =
+        "Failed to connect:\nMatchmaking detected split-tunneling or interfering network software. " +
+        "Ensure MMS and gameplay traffic use the same network path.";
+
+    /// <summary>
     /// Large blocking message shown when the client must update before using matchmaking.
     /// </summary>
     private const string MatchmakingUpdateRequiredText =
@@ -1269,6 +1276,11 @@ internal class ConnectInterface {
 
                 if (MmsClient.LastMatchmakingError == MatchmakingError.UpdateRequired) {
                     ActivateMatchmakingVersionBlock();
+                    yield break;
+                }
+
+                if (MmsClient.LastJoinFailureReason == "client_path_mismatch") {
+                    ShowFeedback(Color.red, ErrorSplitTunnelDetected);
                     yield break;
                 }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Matchmaking / Hole-Punch Traversal Failures</h1>
<h2>Summary</h2>
<p>Identified and fixed <strong>two distinct bugs</strong> in the matchmaking/hole-punch flow. Each manifested as traversal instability, but they were independent correctness issues with different root causes and fixes.</p>
<hr>
<h2>Bug 1: Client Endpoint Built from Mismatched Sources</h2>
<h3>Problem: </h3>
<p>MMS constructed the client punch target using a hybrid of two different network paths:</p>
<ul>
<li><strong>Client IP</strong> --  from the HTTP join request</li>
<li><strong>Client external port</strong> -- from UDP discovery</li>
</ul>
<p>This assumption is unsafe. When the HTTP-visible path and UDP-visible path differ (e.g due to NAT asymmetry or split routing), MMS can generate a client endpoint that does not correspond to any real, reachable socket.</p>
<h3>Fix: </h3>
<p>MMS now prefers the <strong>UDP-discovered client IP</strong> for <code>start_punch</code> once discovery completes, instead of reusing the HTTP-side client IP.</p>
<hr>
<h2>Bug 2: Stale Host Mapping Reused After Refresh Request</h2>
<h3>Problem: </h3>
<p>When the client discovery packet arrived, MMS called <code>refresh_host_mapping</code> on the host but <strong>did not wait</strong> for a fresh host discovery result. If <code>lobby.ExternalPort</code> already held a cached value, <code>start_punch</code> could be issued immediately using stale mapping data.</p>
<p>This produced the <strong>"works immediately, fails later"</strong> failure pattern -- connections that appeared to succeed on first attempt but broke on subsequent joins.</p>
<h3>Fix: </h3>
<ul>
<li>Added a <strong>per-join freshness barrier</strong></li>
<li>After requesting a host refresh, the join now waits for a fresh host discovery event before allowing <code>start_punch</code> to proceed</li>
</ul>
<hr>
</body>
</html>