### PR TITLE
Make use of RTT thresholds for improved interpolation

### DIFF
--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -1190,8 +1190,9 @@ internal class ClientManager : IClientManager {
             return;
         }
 
-        // Update all remote player interpolations in one centralized loop
-        _playerManager.UpdateInterpolations(Time.deltaTime);
+        // Update all remote player interpolations in one centralized loop.
+        // We also pass the latest measured RTT so the interpolator can adapt to ping.
+        _playerManager.UpdateInterpolations(Time.deltaTime, _netClient.UpdateManager.AverageRtt);
 
         var heroTransform = HeroController.instance.transform;
 

--- a/SSMP/Game/Client/Entity/Entity.cs
+++ b/SSMP/Game/Client/Entity/Entity.cs
@@ -628,6 +628,14 @@ internal class Entity {
                 Object.Host.SetActive(false);
             }
 
+            if (
+                Object.Client != null && 
+                Object.Client.TryGetComponent<PredictiveInterpolation>(out var interpolation)
+            ) {
+                interpolation.AdaptToRTT(_netClient.UpdateManager.AverageRtt);
+                interpolation.ManualUpdate(Time.deltaTime);
+            }
+
             return;
         }
 

--- a/SSMP/Game/Client/PlayerManager.cs
+++ b/SSMP/Game/Client/PlayerManager.cs
@@ -111,12 +111,18 @@ internal class PlayerManager : IPlayerManager {
 
     /// <summary>
     /// Updates interpolation for all active players.
+    /// Also feeds the current network RTT (round-trip time) into each player's
+    /// interpolation so it can adapt smoothing/prediction to the actual ping.
     /// </summary>
     /// <param name="dt">The delta time for this frame.</param>
-    public void UpdateInterpolations(float dt) {
+    /// <param name="currentRttMs">The current average round-trip time in milliseconds.</param>
+    public void UpdateInterpolations(float dt, float currentRttMs) {
         foreach (var container in _activePlayers.Values) {
             // Cache component reference if accessed frequently
             if (container.TryGetComponent<PredictiveInterpolation>(out var interpolation)) {
+                // Tell the interpolator what the current ping is, so it can pick
+                // a smoothing tier (LAN / Excellent / Good / Fair / Poor).
+                interpolation.AdaptToRTT(currentRttMs);
                 interpolation.ManualUpdate(dt);
             }
         }


### PR DESCRIPTION
AdaptToRTT wasn't being called anywhere, so its system of adjusting based on the "tier" of connection wasn't occurring: the values _adaptedCorrectionTime, _adaptedPredictionCapMultiplier, and _adaptedDecayMultiplier were unadjusted after being initialized in Awake(). By adding currentRttMs as a parameter of UpdateInterpolations, we can provide the AverageRtt and update these values for use in the ManualUpdate method afterward. (I'm unsure if this wasn't being used for a reason or if it was just an oversight, but hopefully this is helpful.)