### PR TITLE
Remove silent timeout path in OnP2PSessionRequest

### DIFF
--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -1369,6 +1369,9 @@ internal abstract class ServerManager : IServerManager {
             }
         }
 
+        // If this is the same player reconnecting, clear the old session before we evaluate username collisions
+        ReplaceExistingSessionIfPresent(netServerClient, clientInfo, uniqueIdentifier);
+
         // Check whether the username is not already in use
         foreach (var existingPlayerData in _playerData.Values) {
             if (existingPlayerData.Username.ToLower().Equals(clientInfo.Username.ToLower())) {
@@ -1482,6 +1485,33 @@ internal abstract class ServerManager : IServerManager {
         } catch (Exception e) {
             Logger.Error($"Exception thrown while invoking PlayerConnect event:\n{e}");
         }
+    }
+    
+    /// <summary>
+    /// If the connecting client matches an active player identity, disconnect the old session so the new
+    /// transport can take over cleanly.
+    /// </summary>
+    /// <param name="netServerClient">The connecting net server client.</param>
+    /// <param name="clientInfo">The connection info for the new session.</param>
+    /// <param name="uniqueIdentifier">The transport-level unique identifier for the new session.</param>
+    private void ReplaceExistingSessionIfPresent(
+        NetServerClient netServerClient,
+        ClientInfo clientInfo,
+        string uniqueIdentifier
+    ) {
+        var existingPlayer = _playerData.Values.FirstOrDefault(playerData =>
+            playerData.Id != netServerClient.Id
+            && (string.Equals(playerData.UniqueClientIdentifier, uniqueIdentifier, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(playerData.AuthKey, clientInfo.AuthKey, StringComparison.OrdinalIgnoreCase)));
+
+        if (existingPlayer is null)
+            return;
+
+        Logger.Warn(
+            $"Replacing existing session for player '{existingPlayer.Username}' " +
+            $"(ID {existingPlayer.Id}) with new connection from {uniqueIdentifier}");
+
+        ProcessPlayerDisconnect(existingPlayer.Id);
     }
 
     /// <summary>

--- a/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransportServer.cs
+++ b/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransportServer.cs
@@ -196,14 +196,14 @@ internal sealed class SteamEncryptedTransportServer : IEncryptedTransportServer 
         var remoteSteamId = request.m_steamIDRemote;
         Logger.Info($"Steam P2P: Received session request from {remoteSteamId}");
 
-        // Check if we already have a connection for this user
+        // If we already have a connection for this user, remove the stale entry first so the new session
+        // request can replace it.
         if (_clients.TryGetValue(remoteSteamId, out var existingClient)) {
-            Logger.Warn($"Steam P2P: Received new session request from already connected client {remoteSteamId} - closing stale session and ignoring this request to force client retry");
+            Logger.Warn($"Steam P2P: Received new session request from already connected client {remoteSteamId} - closing stale session and accepting new request");
             DisconnectClientInternal(existingClient);
-            return;
         }
 
-        // Accept the session (only if no stale session existed)
+        // Accept the session
         if (!SteamNetworking.AcceptP2PSessionWithUser(remoteSteamId)) {
             Logger.Warn($"Steam P2P: Failed to accept session from {remoteSteamId}");
             return;


### PR DESCRIPTION
The previous return path seems problematic because it expects the connecting user to retry, which is not a given. A timeout without further explanation to the connecting client indicates that the connection might not be possible, as only the host is informed of the "why." This change makes OnP2PSessionRequest attempt to accept the oncoming connection rather than disconnecting.