### PR TITLE
Bring Steam P2P connection timeouts in line with UDP

### DIFF
--- a/SSMP/Networking/Client/NetClient.cs
+++ b/SSMP/Networking/Client/NetClient.cs
@@ -152,10 +152,8 @@ internal class NetClient : INetClient {
                     UpdateManager.StartUpdates();
                     _chunkSender.Start();
 
-                    // Only UDP/HolePunch need timeout management (Steam has built-in connection tracking)
-                    if (_transport.RequiresCongestionManagement) {
-                        UpdateManager.TimeoutEvent += OnConnectTimedOut;
-                    }
+                    // Subscribes all connection methods to timeout events
+                    UpdateManager.TimeoutEvent += OnConnectTimedOut;
 
                     _connectionManager.StartConnection(username, authKey, addonData);
                 } catch (TlsTimeoutException) {

--- a/SSMP/Networking/Transport/Common/IEncryptedTransport.cs
+++ b/SSMP/Networking/Transport/Common/IEncryptedTransport.cs
@@ -28,12 +28,6 @@ internal interface IEncryptedTransport {
     void Send(byte[] buffer, int offset, int length);
 
     /// <summary>
-    /// Indicates whether this transport requires application-level congestion management.
-    /// Returns false for transports with built-in congestion handling (e.g., Steam P2P).
-    /// </summary>
-    bool RequiresCongestionManagement { get; }
-
-    /// <summary>
     /// Indicates whether the application must handle reliability (retransmission).
     /// Returns false for transports with built-in reliable delivery (e.g., Steam P2P).
     /// </summary>

--- a/SSMP/Networking/Transport/Common/IEncryptedTransportClient.cs
+++ b/SSMP/Networking/Transport/Common/IEncryptedTransportClient.cs
@@ -24,12 +24,6 @@ internal interface IEncryptedTransportClient {
     IPEndPoint? EndPoint { get; }
 
     /// <summary>
-    /// Indicates whether this transport requires application-level congestion management.
-    /// Returns false for transports with built-in congestion handling (e.g., Steam P2P).
-    /// </summary>
-    bool RequiresCongestionManagement { get; }
-
-    /// <summary>
     /// Indicates whether the application must handle reliability (retransmission).
     /// Returns false for transports with built-in reliable delivery (e.g., Steam P2P).
     /// </summary>

--- a/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransport.cs
+++ b/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransport.cs
@@ -91,12 +91,6 @@ internal class HolePunchEncryptedTransport : IEncryptedTransport {
     public event Action<byte[], int>? DataReceivedEvent;
 
     /// <summary>
-    /// Indicates whether this transport requires congestion management.
-    /// UDP provides no congestion control, so higher layers must implement it.
-    /// </summary>
-    public bool RequiresCongestionManagement => true;
-
-    /// <summary>
     /// Indicates whether this transport requires reliability mechanisms.
     /// UDP is unreliable, so higher layers must implement retransmission.
     /// </summary>

--- a/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransportClient.cs
+++ b/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransportClient.cs
@@ -30,9 +30,6 @@ internal class HolePunchEncryptedTransportClient : IEncryptedTransportClient {
     IPEndPoint IEncryptedTransportClient.EndPoint => EndPoint;
 
     /// <inheritdoc />
-    public bool RequiresCongestionManagement => true;
-
-    /// <inheritdoc />
     public bool RequiresReliability => true;
 
     /// <inheritdoc />

--- a/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransport.cs
+++ b/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransport.cs
@@ -40,9 +40,6 @@ internal sealed class SteamEncryptedTransport : IReliableTransport {
     public event Action<byte[], int>? DataReceivedEvent;
 
     /// <inheritdoc />
-    public bool RequiresCongestionManagement => false;
-
-    /// <inheritdoc />
     public bool RequiresReliability => false;
 
     /// <inheritdoc />

--- a/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransportClient.cs
+++ b/SSMP/Networking/Transport/SteamP2P/SteamEncryptedTransportClient.cs
@@ -32,9 +32,6 @@ internal class SteamEncryptedTransportClient : IReliableTransportClient {
     public IPEndPoint? EndPoint => null; // Steam doesn't need throttling
 
     /// <inheritdoc />
-    public bool RequiresCongestionManagement => false;
-
-    /// <inheritdoc />
     public bool RequiresReliability => false;
 
     /// <inheritdoc />

--- a/SSMP/Networking/Transport/UDP/UdpEncryptedTransport.cs
+++ b/SSMP/Networking/Transport/UDP/UdpEncryptedTransport.cs
@@ -22,9 +22,6 @@ internal class UdpEncryptedTransport : IEncryptedTransport {
     public event Action<byte[], int>? DataReceivedEvent;
 
     /// <inheritdoc />
-    public bool RequiresCongestionManagement => true;
-
-    /// <inheritdoc />
     public bool RequiresReliability => true;
 
     /// <inheritdoc />

--- a/SSMP/Networking/Transport/UDP/UdpEncryptedTransportClient.cs
+++ b/SSMP/Networking/Transport/UDP/UdpEncryptedTransportClient.cs
@@ -27,9 +27,6 @@ internal class UdpEncryptedTransportClient : IEncryptedTransportClient {
     public IPEndPoint EndPoint => _dtlsServerClient.EndPoint;
 
     /// <inheritdoc />
-    public bool RequiresCongestionManagement => true;
-
-    /// <inheritdoc />
     public bool RequiresReliability => true;
 
     /// <inheritdoc />


### PR DESCRIPTION
According to the documentation, Steam tracks connection failures through `P2PSessionConnectFail`, which is called when packets can't get through to the specified user. There's a couple potential problems here: (1) [Steam only tracks if packets are sent and no response is made](https://partner.steamgames.com/doc/api/ISteamNetworking#P2PSessionConnectFail_t). If the handshake response stalls, Steam doesn't communicate that to us. An example of how this could happen is in the previous PR (https://github.com/Extremelyd1/SSMP/pull/63). (2) If we rely on Steam's connection failed call, it takes four times to respond as long as the other 5000ms timeouts (which might prompt the user to believe their connection process has frozen indefinitely anyway). Relying on the timeout event the other connection methods use seems like a good alternative.