### PR TITLE
Refactor player settings networking

### DIFF
--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -879,6 +879,7 @@ internal class ClientManager : IClientManager {
             enterSceneData.Username,
             enterSceneData.Position,
             enterSceneData.Scale,
+            enterSceneData.CrestType,
             enterSceneData.Team,
             enterSceneData.SkinId
         );

--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -696,8 +696,12 @@ internal class ClientManager : IClientManager {
         }
 
         // Fill the player data dictionary with the info from the packet
-        foreach (var (id, username) in serverInfo.PlayerInfo) {
-            _playerData[id] = new ClientPlayerData(id, username);
+        foreach (var playerInfo in serverInfo.PlayerInfos) {
+            _playerData[playerInfo.Id] = new ClientPlayerData {
+                Id = playerInfo.Id, 
+                Username = playerInfo.Username, 
+                CrestType = playerInfo.CrestType
+            };
         }
 
         // Add the username to the player if we are in-game already
@@ -760,7 +764,10 @@ internal class ClientManager : IClientManager {
     private void OnPlayerConnect(PlayerConnect playerConnect) {
         Logger.Info($"Received PlayerConnect data for ID: {playerConnect.Id}");
 
-        var playerData = new ClientPlayerData(playerConnect.Id, playerConnect.Username);
+        var playerData = new ClientPlayerData {
+            Id = playerConnect.Id,
+            Username = playerConnect.Username,
+        };
         _playerData[playerConnect.Id] = playerData;
 
         UiManager.InternalChatBox.AddMessage($"Player '{playerConnect.Username}' connected to the server");
@@ -865,23 +872,19 @@ internal class ClientManager : IClientManager {
         // Read ID from player data
         var id = enterSceneData.Id;
 
-        Logger.Info($"Player {id} entered scene");
-
         if (!_playerData.TryGetValue(id, out var playerData)) {
-            playerData = new ClientPlayerData(id, enterSceneData.Username);
-            _playerData[id] = playerData;
+            Logger.Warn($"Could not find player data for player '{id}' entering scene");
+            return;
         }
+
+        Logger.Info($"Player {id} entered scene");
 
         playerData.IsInLocalScene = true;
 
         _playerManager.SpawnPlayer(
             playerData,
-            enterSceneData.Username,
             enterSceneData.Position,
-            enterSceneData.Scale,
-            enterSceneData.CrestType,
-            enterSceneData.Team,
-            enterSceneData.SkinId
+            enterSceneData.Scale
         );
         _animationManager.UpdatePlayerAnimation(id, enterSceneData.AnimationClipId, 0, playerData.CrestType);
 

--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -699,7 +699,9 @@ internal class ClientManager : IClientManager {
         foreach (var playerInfo in serverInfo.PlayerInfos) {
             _playerData[playerInfo.Id] = new ClientPlayerData {
                 Id = playerInfo.Id, 
-                Username = playerInfo.Username, 
+                Username = playerInfo.Username,
+                Team = playerInfo.Team,
+                SkinId = playerInfo.SkinId,
                 CrestType = playerInfo.CrestType
             };
         }

--- a/SSMP/Game/Client/ClientPlayerData.cs
+++ b/SSMP/Game/Client/ClientPlayerData.cs
@@ -1,4 +1,3 @@
-using System;
 using SSMP.Api.Client;
 using SSMP.Internals;
 using UnityEngine;
@@ -8,10 +7,10 @@ namespace SSMP.Game.Client;
 /// <inheritdoc />
 internal class ClientPlayerData : IClientPlayer {
     /// <inheritdoc />
-    public ushort Id { get; }
+    public required ushort Id { get; init; }
 
     /// <inheritdoc />
-    public string Username { get; }
+    public required string Username { get; init; }
 
     /// <inheritdoc />
     public bool IsInLocalScene { get; set; }
@@ -30,12 +29,4 @@ internal class ClientPlayerData : IClientPlayer {
 
     /// <inheritdoc />
     public CrestType CrestType { get; set; }
-
-    public ClientPlayerData(
-        ushort id,
-        string username
-    ) {
-        Id = id;
-        Username = username;
-    }
 }

--- a/SSMP/Game/Client/PlayerManager.cs
+++ b/SSMP/Game/Client/PlayerManager.cs
@@ -434,20 +434,12 @@ internal class PlayerManager : IPlayerManager {
     /// Spawn a new player object with the given data.
     /// </summary>
     /// <param name="playerData">The client player data for the player.</param>
-    /// <param name="name">The username of the player.</param>
     /// <param name="position">The Vector2 denoting the position of the player.</param>
     /// <param name="scale">The boolean representing the scale of the player.</param>
-    /// <param name="crestType">The crest the player is using.</param>
-    /// <param name="team">The team the player is on.</param>
-    /// <param name="skinId">The ID of the skin the player is using.</param>
     public void SpawnPlayer(
         ClientPlayerData playerData,
-        string name,
         Math_Vector2 position,
-        bool scale,
-        CrestType crestType,
-        Team team,
-        byte skinId
+        bool scale
     ) {
         // First recycle the player by player data if they have an active container
         RecyclePlayerByData(playerData);
@@ -479,17 +471,14 @@ internal class PlayerManager : IPlayerManager {
         playerContainer.SetActive(true);
         playerContainer.SetActiveChildren(true);
 
-        AddNameToPlayer(playerContainer, name, team);
+        AddNameToPlayer(playerContainer, playerData.Username, playerData.Team);
 
         // Let the SkinManager update the skin
-        _skinManager.UpdatePlayerSkin(playerObject, skinId);
+        _skinManager.UpdatePlayerSkin(playerObject, playerData.SkinId);
 
         // Store the player data
         playerData.PlayerContainer = playerContainer;
         playerData.PlayerObject = playerObject;
-        playerData.CrestType = crestType;
-        playerData.Team = team;
-        playerData.SkinId = skinId;
     }
 
     /// <summary>

--- a/SSMP/Game/Client/PlayerManager.cs
+++ b/SSMP/Game/Client/PlayerManager.cs
@@ -437,6 +437,7 @@ internal class PlayerManager : IPlayerManager {
     /// <param name="name">The username of the player.</param>
     /// <param name="position">The Vector2 denoting the position of the player.</param>
     /// <param name="scale">The boolean representing the scale of the player.</param>
+    /// <param name="crestType">The crest the player is using.</param>
     /// <param name="team">The team the player is on.</param>
     /// <param name="skinId">The ID of the skin the player is using.</param>
     public void SpawnPlayer(
@@ -444,6 +445,7 @@ internal class PlayerManager : IPlayerManager {
         string name,
         Math_Vector2 position,
         bool scale,
+        CrestType crestType,
         Team team,
         byte skinId
     ) {
@@ -485,6 +487,7 @@ internal class PlayerManager : IPlayerManager {
         // Store the player data
         playerData.PlayerContainer = playerContainer;
         playerData.PlayerObject = playerObject;
+        playerData.CrestType = crestType;
         playerData.Team = team;
         playerData.SkinId = skinId;
     }

--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -498,6 +498,7 @@ internal abstract class ServerManager : IServerManager {
                     playerData.Username,
                     playerData.Position ?? Vector2.Zero,
                     playerData.Scale,
+                    playerData.CrestType,
                     playerData.Team,
                     playerData.SkinId,
                     playerData.AnimationId
@@ -514,6 +515,7 @@ internal abstract class ServerManager : IServerManager {
                     Username = otherPlayerData.Username,
                     Position = otherPlayerData.Position ?? Vector2.Zero,
                     Scale = otherPlayerData.Scale,
+                    CrestType = otherPlayerData.CrestType,
                     Team = otherPlayerData.Team,
                     SkinId = otherPlayerData.SkinId,
                     AnimationClipId = otherPlayerData.AnimationId

--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -1451,6 +1451,8 @@ internal abstract class ServerManager : IServerManager {
             playerInfo.Add(new ServerInfo.PlayerInfo {
                 Id = otherId,
                 Username = otherPd.Username,
+                Team = otherPd.Team,
+                SkinId = otherPd.SkinId,
                 CrestType = otherPd.CrestType
             });
 

--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -495,12 +495,8 @@ internal abstract class ServerManager : IServerManager {
 
                 _netServer.GetUpdateManagerForClient(idPlayerDataPair.Key)?.AddPlayerEnterSceneData(
                     playerData.Id,
-                    playerData.Username,
                     playerData.Position ?? Vector2.Zero,
                     playerData.Scale,
-                    playerData.CrestType,
-                    playerData.Team,
-                    playerData.SkinId,
                     playerData.AnimationId
                 );
 
@@ -512,12 +508,8 @@ internal abstract class ServerManager : IServerManager {
                 // notifying that these players are already in this new scene.
                 enterSceneList.Add(new ClientPlayerEnterScene {
                     Id = idPlayerDataPair.Key,
-                    Username = otherPlayerData.Username,
                     Position = otherPlayerData.Position ?? Vector2.Zero,
                     Scale = otherPlayerData.Scale,
-                    CrestType = otherPlayerData.CrestType,
-                    Team = otherPlayerData.Team,
-                    SkinId = otherPlayerData.SkinId,
                     AnimationClipId = otherPlayerData.AnimationId
                 });
             }
@@ -1446,7 +1438,7 @@ internal abstract class ServerManager : IServerManager {
         serverInfo.FullSynchronisation = FullSynchronisation;
         
         // Construct the player info to send to the new client in the server info
-        var playerInfo = new List<(ushort, string)>();
+        var playerInfo = new List<ServerInfo.PlayerInfo>();
 
         foreach (var idPlayerDataPair in _playerData) {
             var otherId = idPlayerDataPair.Key;
@@ -1456,7 +1448,11 @@ internal abstract class ServerManager : IServerManager {
 
             var otherPd = idPlayerDataPair.Value;
 
-            playerInfo.Add((otherId, otherPd.Username));
+            playerInfo.Add(new ServerInfo.PlayerInfo {
+                Id = otherId,
+                Username = otherPd.Username,
+                CrestType = otherPd.CrestType
+            });
 
             // Send to the other players that this client has just connected
             _netServer.GetUpdateManagerForClient(otherId)?.AddPlayerConnectData(
@@ -1465,7 +1461,7 @@ internal abstract class ServerManager : IServerManager {
             );
         }
 
-        serverInfo.PlayerInfo = playerInfo;
+        serverInfo.PlayerInfos = playerInfo;
 
         // if (FullSynchronisation) {
         //     // Obtain the save data for the connecting client and add it to the server info

--- a/SSMP/Networking/Packet/Data/PlayerEnterScene.cs
+++ b/SSMP/Networking/Packet/Data/PlayerEnterScene.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using SSMP.Game;
+using SSMP.Internals;
 using SSMP.Math;
 
 namespace SSMP.Networking.Packet.Data;
@@ -22,6 +23,11 @@ internal class ClientPlayerEnterScene : GenericClientData {
     /// The scale of the player.
     /// </summary>
     public bool Scale { get; set; }
+
+    /// <summary>
+    /// The crest of the player.
+    /// </summary>
+    public CrestType CrestType { get; set; }
 
     /// <summary>
     /// The team of the player.
@@ -53,6 +59,7 @@ internal class ClientPlayerEnterScene : GenericClientData {
 
         packet.Write(Position);
         packet.Write(Scale);
+        packet.Write((byte) CrestType);
         packet.Write((byte) Team);
         packet.Write(SkinId);
 
@@ -66,6 +73,7 @@ internal class ClientPlayerEnterScene : GenericClientData {
 
         Position = packet.ReadVector2();
         Scale = packet.ReadBool();
+        CrestType = (CrestType) packet.ReadByte();
         Team = (Team) packet.ReadByte();
         SkinId = packet.ReadByte();
         AnimationClipId = packet.ReadUShort();

--- a/SSMP/Networking/Packet/Data/PlayerEnterScene.cs
+++ b/SSMP/Networking/Packet/Data/PlayerEnterScene.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using SSMP.Game;
-using SSMP.Internals;
 using SSMP.Math;
 
 namespace SSMP.Networking.Packet.Data;
@@ -10,11 +8,6 @@ namespace SSMP.Networking.Packet.Data;
 /// </summary>
 internal class ClientPlayerEnterScene : GenericClientData {
     /// <summary>
-    /// The username of the player.
-    /// </summary>
-    public string Username { get; set; } = null!;
-
-    /// <summary>
     /// The position of the player.
     /// </summary>
     public Vector2 Position { get; set; } = null!;
@@ -23,21 +16,6 @@ internal class ClientPlayerEnterScene : GenericClientData {
     /// The scale of the player.
     /// </summary>
     public bool Scale { get; set; }
-
-    /// <summary>
-    /// The crest of the player.
-    /// </summary>
-    public CrestType CrestType { get; set; }
-
-    /// <summary>
-    /// The team of the player.
-    /// </summary>
-    public Team Team { get; set; }
-
-    /// <summary>
-    /// The ID of the skin of the player.
-    /// </summary>
-    public byte SkinId { get; set; }
 
     /// <summary>
     /// The ID of the animation clip of the player.
@@ -55,13 +33,9 @@ internal class ClientPlayerEnterScene : GenericClientData {
     /// <inheritdoc />
     public override void WriteData(IPacket packet) {
         packet.Write(Id);
-        packet.Write(Username);
 
         packet.Write(Position);
         packet.Write(Scale);
-        packet.Write((byte) CrestType);
-        packet.Write((byte) Team);
-        packet.Write(SkinId);
 
         packet.Write(AnimationClipId);
     }
@@ -69,13 +43,10 @@ internal class ClientPlayerEnterScene : GenericClientData {
     /// <inheritdoc />
     public override void ReadData(IPacket packet) {
         Id = packet.ReadUShort();
-        Username = packet.ReadString();
 
         Position = packet.ReadVector2();
         Scale = packet.ReadBool();
-        CrestType = (CrestType) packet.ReadByte();
-        Team = (Team) packet.ReadByte();
-        SkinId = packet.ReadByte();
+
         AnimationClipId = packet.ReadUShort();
     }
 }
@@ -119,10 +90,10 @@ internal class ClientPlayerAlreadyInScene : IPacketData {
     /// Construct the client player already in scene data.
     /// </summary>
     public ClientPlayerAlreadyInScene() {
-        PlayerEnterSceneList = new List<ClientPlayerEnterScene>();
-        EntitySpawnList = new List<EntitySpawn>();
-        EntityUpdateList = new List<EntityUpdate>();
-        ReliableEntityUpdateList = new List<ReliableEntityUpdate>();
+        PlayerEnterSceneList = [];
+        EntitySpawnList = [];
+        EntityUpdateList = [];
+        ReliableEntityUpdateList = [];
     }
 
     /// <inheritdoc />

--- a/SSMP/Networking/Packet/Data/ServerInfo.cs
+++ b/SSMP/Networking/Packet/Data/ServerInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using SSMP.Api.Addon;
+using SSMP.Internals;
 
 namespace SSMP.Networking.Packet.Data;
 
@@ -53,7 +54,7 @@ internal class ServerInfo : IPacketData {
     /// <summary>
     /// List of ID, username pairs for each connected client.
     /// </summary>
-    public List<(ushort, string)> PlayerInfo { get; set; } = null!;
+    public List<PlayerInfo> PlayerInfos { get; set; } = null!;
 
     /// <inheritdoc />
     public void WriteData(IPacket packet) {
@@ -72,19 +73,16 @@ internal class ServerInfo : IPacketData {
 
             // CurrentSave.WriteData(packet);
         
-            packet.Write((ushort) PlayerInfo.Count);
+            packet.Write((ushort) PlayerInfos.Count);
 
-            foreach (var (id, username) in PlayerInfo) {
-                packet.Write(id);
-                packet.Write(username);
+            foreach (var playerInfo in PlayerInfos) {
+                playerInfo.WriteData(packet);
             }
 
             return;
         }
 
         if (ConnectionResult == ServerConnectionResult.InvalidAddons) {
-            AddonData ??= [];
-            
             var addonDataLength = (byte) System.Math.Min(byte.MaxValue, AddonData.Count);
 
             packet.Write(addonDataLength);
@@ -122,12 +120,9 @@ internal class ServerInfo : IPacketData {
         
             var length = packet.ReadUShort();
 
-            PlayerInfo = new List<(ushort, string)>();
+            PlayerInfos = [];
             for (var i = 0; i < length; i++) {
-                PlayerInfo.Add((
-                    packet.ReadUShort(),
-                    packet.ReadString()
-                ));
+                PlayerInfos.Add(PlayerInfo.ReadData(packet));
             }
 
             return;
@@ -153,5 +148,43 @@ internal class ServerInfo : IPacketData {
         }
 
         ConnectionRejectedMessage = packet.ReadString();
+    }
+
+    /// <summary>
+    /// Class for player info that is used in the server info sent to the player.
+    /// </summary>
+    public class PlayerInfo {
+        /// <summary>
+        /// The ID of the player.
+        /// </summary>
+        public required ushort Id { get; init; }
+        /// <summary>
+        /// The username of the player.
+        /// </summary>
+        public required string Username { get; init; }
+        /// <summary>
+        /// The current crest type of the player.
+        /// </summary>
+        public required CrestType CrestType { get; init; }
+
+        /// <inheritdoc cref="IPacketData.WriteData" />
+        public void WriteData(IPacket packet) {
+            packet.Write(Id);
+            packet.Write(Username);
+            packet.Write((byte) CrestType);
+        }
+
+        /// <summary>
+        /// Read the data from the given packet into a new instance of <see cref="PlayerInfo"/>.
+        /// </summary>
+        /// <param name="packet">The packet to read from.</param>
+        /// <returns>A new instance of <see cref="PlayerInfo"/>.</returns>
+        public static PlayerInfo ReadData(IPacket packet) {
+            return new PlayerInfo {
+                Id = packet.ReadUShort(),
+                Username = packet.ReadString(),
+                CrestType = (CrestType) packet.ReadByte()
+            };
+        }
     }
 }

--- a/SSMP/Networking/Packet/Data/ServerInfo.cs
+++ b/SSMP/Networking/Packet/Data/ServerInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using SSMP.Api.Addon;
+using SSMP.Game;
 using SSMP.Internals;
 
 namespace SSMP.Networking.Packet.Data;
@@ -163,6 +164,14 @@ internal class ServerInfo : IPacketData {
         /// </summary>
         public required string Username { get; init; }
         /// <summary>
+        /// The team of the player.
+        /// </summary>
+        public required Team Team { get; init; }
+        /// <summary>
+        /// The skin ID of the player.
+        /// </summary>
+        public required byte SkinId { get; init; }
+        /// <summary>
         /// The current crest type of the player.
         /// </summary>
         public required CrestType CrestType { get; init; }
@@ -171,6 +180,8 @@ internal class ServerInfo : IPacketData {
         public void WriteData(IPacket packet) {
             packet.Write(Id);
             packet.Write(Username);
+            packet.Write((byte) Team);
+            packet.Write(SkinId);
             packet.Write((byte) CrestType);
         }
 
@@ -183,6 +194,8 @@ internal class ServerInfo : IPacketData {
             return new PlayerInfo {
                 Id = packet.ReadUShort(),
                 Username = packet.ReadString(),
+                Team = (Team) packet.ReadByte(),
+                SkinId = packet.ReadByte(),
                 CrestType = (CrestType) packet.ReadByte()
             };
         }

--- a/SSMP/Networking/Server/ServerUpdateManager.cs
+++ b/SSMP/Networking/Server/ServerUpdateManager.cs
@@ -163,32 +163,20 @@ internal class ServerUpdateManager : UpdateManager<ClientUpdatePacket, ClientUpd
     /// Add player enter scene data to the current packet.
     /// </summary>
     /// <param name="id">The ID of the player.</param>
-    /// <param name="username">The username of the player.</param>
     /// <param name="position">The position of the player.</param>
     /// <param name="scale">The scale of the player.</param>
-    /// <param name="crestType">The crest the player is using.</param>
-    /// <param name="team">The team of the player.</param>
-    /// <param name="skinId">The ID of the skin of the player.</param>
     /// <param name="animationClipId">The ID of the animation clip of the player.</param>
     public void AddPlayerEnterSceneData(
         ushort id,
-        string username,
         Vector2 position,
         bool scale,
-        CrestType crestType,
-        Team team,
-        byte skinId,
         ushort animationClipId
     ) {
         lock (Lock) {
             var playerEnterScene =
                 FindOrCreatePacketData<ClientPlayerEnterScene>(id, ClientUpdatePacketId.PlayerEnterScene);
-            playerEnterScene.Username = username;
             playerEnterScene.Position = position;
             playerEnterScene.Scale = scale;
-            playerEnterScene.CrestType = crestType;
-            playerEnterScene.Team = team;
-            playerEnterScene.SkinId = skinId;
             playerEnterScene.AnimationClipId = animationClipId;
         }
     }

--- a/SSMP/Networking/Server/ServerUpdateManager.cs
+++ b/SSMP/Networking/Server/ServerUpdateManager.cs
@@ -166,6 +166,7 @@ internal class ServerUpdateManager : UpdateManager<ClientUpdatePacket, ClientUpd
     /// <param name="username">The username of the player.</param>
     /// <param name="position">The position of the player.</param>
     /// <param name="scale">The scale of the player.</param>
+    /// <param name="crestType">The crest the player is using.</param>
     /// <param name="team">The team of the player.</param>
     /// <param name="skinId">The ID of the skin of the player.</param>
     /// <param name="animationClipId">The ID of the animation clip of the player.</param>
@@ -174,6 +175,7 @@ internal class ServerUpdateManager : UpdateManager<ClientUpdatePacket, ClientUpd
         string username,
         Vector2 position,
         bool scale,
+        CrestType crestType,
         Team team,
         byte skinId,
         ushort animationClipId
@@ -184,6 +186,7 @@ internal class ServerUpdateManager : UpdateManager<ClientUpdatePacket, ClientUpd
             playerEnterScene.Username = username;
             playerEnterScene.Position = position;
             playerEnterScene.Scale = scale;
+            playerEnterScene.CrestType = crestType;
             playerEnterScene.Team = team;
             playerEnterScene.SkinId = skinId;
             playerEnterScene.AnimationClipId = animationClipId;


### PR DESCRIPTION
Fixes the issue where other player's crest information is not networked to new players when joining a server. This has been fixed by sending the data with the same method that sends players teams, skins, and positions.