### PR TITLE
Fix player and attack layers

### DIFF
--- a/SSMP/Animation/DamageAnimationEffect.cs
+++ b/SSMP/Animation/DamageAnimationEffect.cs
@@ -10,6 +10,11 @@ namespace SSMP.Animation;
 /// </summary>
 internal abstract class DamageAnimationEffect : AnimationEffect {
     /// <summary>
+    /// The object layer for attacks.
+    /// </summary>
+    protected const int AttackLayer = (int) GlobalEnums.PhysLayers.HERO_ATTACK;
+
+    /// <summary>
     /// Whether this effect should deal damage.
     /// </summary>
     protected bool ShouldDoDamage;
@@ -65,5 +70,23 @@ internal abstract class DamageAnimationEffect : AnimationEffect {
 
         RemoveDamageHeroComponent(target);
         return null;
+    }
+
+    /// <summary>
+    /// Fixes an attack's <see cref="DamageEnemies"/> component.
+    /// </summary>
+    /// <param name="target">The object with the <see cref="DamageEnemies"/> component.</param>
+    protected void FixDamageEnemies(GameObject target) {
+        // Add if we want to disable enemy damage
+        //if (!ServerSettings.AllowDamageEnemies) {
+        //    target.DestroyComponent<DamageEnemies>();
+        //}
+
+        if (target.TryGetComponent<DamageEnemies>(out var damageEnemies)) {
+            damageEnemies.doesNotTink = true;
+            damageEnemies.doesNotTinkThroughWalls = true;
+            damageEnemies.doesNotParry = true;
+            damageEnemies.silkGeneration = HitSilkGeneration.None;
+        }
     }
 }

--- a/SSMP/Animation/DamageAnimationEffect.cs
+++ b/SSMP/Animation/DamageAnimationEffect.cs
@@ -73,10 +73,11 @@ internal abstract class DamageAnimationEffect : AnimationEffect {
     }
 
     /// <summary>
-    /// Fixes an attack's <see cref="DamageEnemies"/> component.
+    /// Fixes a remote attack's <see cref="DamageEnemies"/> component by disabling various properties that would
+    /// interfere with the local player.
     /// </summary>
     /// <param name="target">The object with the <see cref="DamageEnemies"/> component.</param>
-    protected void FixDamageEnemies(GameObject target) {
+    protected static void FixDamageEnemies(GameObject target) {
         // Add if we want to disable enemy damage
         //if (!ServerSettings.AllowDamageEnemies) {
         //    target.DestroyComponent<DamageEnemies>();

--- a/SSMP/Animation/Effects/BindBurst.cs
+++ b/SSMP/Animation/Effects/BindBurst.cs
@@ -142,11 +142,13 @@ internal class BindBurst : Bind {
                 return;
             }
 
-            damager.layer = (int) GlobalEnums.PhysLayers.HERO_ATTACK;
+            damager.layer = AttackLayer;
 
             var damage = upgraded ? ServerSettings.ClawMirrorUpgradedDamage : ServerSettings.ClawMirrorDamage;
             var damageComponent = AddDamageHeroComponent(damager, damage);
             damageComponent.hazardType = GlobalEnums.HazardType.EXPLOSION;
+
+            FixDamageEnemies(damager);
         }
     }
 
@@ -225,6 +227,7 @@ internal class BindBurst : Bind {
 
             // Add or remove damage component from Damager object
             SetDamageHeroState(child.gameObject);
+            FixDamageEnemies(child.gameObject);
         }
     }
 

--- a/SSMP/Animation/Effects/BindInterrupt.cs
+++ b/SSMP/Animation/Effects/BindInterrupt.cs
@@ -98,6 +98,7 @@ internal class BindInterrupt : Bind {
             var damager = bindBell.FindGameObjectInChildren("damager");
             if (damager != null) {
                 AddDamageHeroComponent(damager, ServerSettings.WardingBellDamage);
+                FixDamageEnemies(damager);
             } else {
                 Logger.Warn("Unable to add damager to warding bell burst");
             }

--- a/SSMP/Animation/Effects/DashSlash.cs
+++ b/SSMP/Animation/Effects/DashSlash.cs
@@ -112,6 +112,8 @@ internal class DashSlash : SlashBase {
                 AddDamageHeroComponent(slashObj, ServerSettings.NeedleDamage);
             }
 
+            FixDamageEnemies(slashObj);
+
             // TODO: Nail imbuement (see OnPlaySlash in NailAttackBase.cs)
             
             // Activate game object in ActivateGameObject action in "Witch?" state

--- a/SSMP/Animation/Effects/NeedleStrike.cs
+++ b/SSMP/Animation/Effects/NeedleStrike.cs
@@ -145,7 +145,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             }
 
             var strikeObj = Object.Instantiate(_chargeSlashBasic, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Hunter)";
 
             ModifyDamagingSlashObject(strikeObj.FindGameObjectInChildren("slash 01"), damage);
@@ -168,7 +168,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             AudioUtil.PlayAudio(_reaperAudioEvent, playerObject);
 
             var strikeObj = Object.Instantiate(_chargeSlashScythe, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Reaper)";
 
             ModifyDamagingSlashObject(strikeObj.FindGameObjectInChildren("slash 01"), damage);
@@ -189,7 +189,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             }
 
             var strikeObj = Object.Instantiate(_chargeSlashWanderer, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Wanderer)";
             
             ModifyDamagingSlashObject(strikeObj, damage);
@@ -235,7 +235,7 @@ internal class NeedleStrike : DamageAnimationEffect {
                 }
 
                 var strikeObj = Object.Instantiate(prefab, playerAttacks.transform);
-                strikeObj.layer = 17;
+                strikeObj.layer = AttackLayer;
                 strikeObj.name = "Needle Strike (Beast)";
                 
                 ModifyDamagingSlashObject(
@@ -282,7 +282,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             _witchAudioEvent ??= GetOrFindNailArtsFsm().GetFirstAction<PlayAudioEvent>("Begin Spin");
 
             var strikeObj = Object.Instantiate(_chargeSlashWitch, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Witch)";
             
             ModifyDamagingSlashObject(strikeObj.FindGameObjectInChildren("damager 01"), damage);
@@ -311,7 +311,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             _architectAudioEvent ??= GetOrFindNailArtsFsm().GetFirstAction<PlayAudioEvent>("Drill Sfx");
 
             var strikeObj = Object.Instantiate(_chargeSlashArchitect, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Architect)";
 
             Object.Destroy(strikeObj.GetComponent<KeepWorldPosition>());
@@ -340,7 +340,7 @@ internal class NeedleStrike : DamageAnimationEffect {
             }
 
             var strikeObj = Object.Instantiate(_chargeSlashShaman, playerAttacks.transform);
-            strikeObj.layer = 17;
+            strikeObj.layer = AttackLayer;
             strikeObj.name = "Needle Strike (Shaman)";
 
             ModifyDamagingSlashObject(strikeObj.FindGameObjectInChildren("damager"), damage);
@@ -395,6 +395,8 @@ internal class NeedleStrike : DamageAnimationEffect {
         }
 
         Object.DestroyImmediate(gameObject.GetComponent<NailSlashTerrainThunk>());
+
+        FixDamageEnemies(gameObject);
 
         if (damage.HasValue) {
             AddDamageHeroComponent(gameObject, damage.Value);

--- a/SSMP/Animation/Effects/SilkSkills/BaseSilkSkill.cs
+++ b/SSMP/Animation/Effects/SilkSkills/BaseSilkSkill.cs
@@ -158,6 +158,9 @@ internal abstract class BaseSilkSkill : DamageAnimationEffect {
             damage += (float) ServerSettings.ShamanDamage / 2;
         }
 
+        damager.layer = AttackLayer;
+        FixDamageEnemies(damager);
+
         return SetDamageHeroState(damager, (int) damage);
     }
 }

--- a/SSMP/Animation/Effects/SlashBase.cs
+++ b/SSMP/Animation/Effects/SlashBase.cs
@@ -130,8 +130,6 @@ internal abstract class SlashBase : ParryableEffect {
         var mesh = slashObj.GetComponent<MeshRenderer>();
         var anim = slashObj.GetComponent<tk2dSpriteAnimator>();
 
-        FixDamageEnemies(slashObj);
-
         string animName;
         Vector3 scale;
         if (nailSlash != null) {

--- a/SSMP/Animation/Effects/SlashBase.cs
+++ b/SSMP/Animation/Effects/SlashBase.cs
@@ -119,6 +119,8 @@ internal abstract class SlashBase : ParryableEffect {
         // Instantiate the slash gameObject from the given prefab
         // and use the attack gameObject as transform reference
         var slashObj = Object.Instantiate(nailAttackBase.gameObject, slashParent.transform);
+        slashObj.layer = AttackLayer;
+        // slashObj.tag = "Nail Beam"; // Add if we want to disable hitting other peoples interactable objects
 
         var nailSlash = slashObj.GetComponent<NailSlash>();
         var downSpike = slashObj.GetComponent<Downspike>();
@@ -127,6 +129,8 @@ internal abstract class SlashBase : ParryableEffect {
         var poly = slashObj.GetComponent<PolygonCollider2D>();
         var mesh = slashObj.GetComponent<MeshRenderer>();
         var anim = slashObj.GetComponent<tk2dSpriteAnimator>();
+
+        FixDamageEnemies(slashObj);
 
         string animName;
         Vector3 scale;
@@ -188,7 +192,9 @@ internal abstract class SlashBase : ParryableEffect {
         if (ServerSettings.IsPvpEnabled && ShouldDoDamage) {
             AddDamageHeroComponent(slashObj, ServerSettings.NeedleDamage);
         }
-        
+
+        FixDamageEnemies(slashObj);
+
         // TODO: nail imbued from NailAttackBase
     }
 

--- a/SSMP/Game/Client/PlayerManager.cs
+++ b/SSMP/Game/Client/PlayerManager.cs
@@ -175,9 +175,7 @@ internal class PlayerManager : IPlayerManager {
             typeof(tk2dSpriteAnimator),
             typeof(Rigidbody2D),
             typeof(CoroutineCancelComponent)
-        ) {
-            layer = 9
-        };
+        );
 
         playerPrefab.transform.SetParent(_playerContainerPrefab.transform);
 


### PR DESCRIPTION
Fixes issues with remote players triggering local events by changing the player's layer to default. Also makes it so that other player's attacks don't trigger parries or 'tinks'. There is commented out code to provide functionality for disabling remote attacks hitting local enemies, as well as for preventing remote attacks from hitting interactable objects, although these need more testing.

Closes #27 
Probably closes #52 