### PR TITLE
Refactor mod settings

### DIFF
--- a/SSMP/Game/Client/ClientManager.cs
+++ b/SSMP/Game/Client/ClientManager.cs
@@ -293,6 +293,10 @@ internal class ClientManager : IClientManager {
         // Register client connect and timeout handler
         _netClient.ConnectEvent += OnClientConnect;
         _netClient.TimeoutEvent += OnTimeout;
+
+        EventHooks.GameManagerQuitGame += () => {
+            _modSettings.Save();
+        };
     }
 
     /// <summary>

--- a/SSMP/Hooks/EventHooks.cs
+++ b/SSMP/Hooks/EventHooks.cs
@@ -57,6 +57,10 @@ public static class EventHooks {
     /// Hook for GameManager.ContinueGame.
     /// </summary>
     private static Hook? _gameManagerContinueGameHook;
+    /// <summary>
+    /// Hook for GameManager.QuitGame.
+    /// </summary>
+    private static Hook? _gameManagerQuitGameHook;
 
     /// <summary>
     /// Hook for tk2dSpriteAnimator.Play.
@@ -148,6 +152,10 @@ public static class EventHooks {
     /// Event that is called when GameManager.ContinueGame is called.
     /// </summary>
     public static event Action? GameManagerContinueGame;
+    /// <summary>
+    /// Event that is called before GameManager.QuitGame is called.
+    /// </summary>
+    public static event Action? GameManagerQuitGame;
 
     /// <summary>
     /// Event that is called when tk2dSpriteAnimator.Play is called.
@@ -269,6 +277,10 @@ public static class EventHooks {
         _gameManagerContinueGameHook = new Hook(
             typeof(GameManager).GetMethod(nameof(GameManager.ContinueGame)),
             OnGameManagerContinueGame
+        );
+        _gameManagerQuitGameHook = new Hook(
+            typeof(GameManager).GetMethod(nameof(GameManager.QuitGame)),
+            OnGameManagerQuitGame
         );
 
         _spriteAnimatorPlayHook = new Hook(
@@ -421,6 +433,12 @@ public static class EventHooks {
         orig(self);
 
         GameManagerContinueGame?.Invoke();
+    }
+
+    private static IEnumerator OnGameManagerQuitGame(Func<GameManager, IEnumerator> orig, GameManager self) {
+        GameManagerQuitGame?.Invoke();
+
+        return orig(self);
     }
 
     private static void OnSpriteAnimatorPlay(

--- a/SSMP/Ui/ConnectInterface.cs
+++ b/SSMP/Ui/ConnectInterface.cs
@@ -1685,6 +1685,8 @@ internal class ConnectInterface {
             return;
         }
 
+        SaveConnectionSettings(null, port, username);
+
         StartHostButtonPressed?.Invoke("", port, username, TransportType.Udp, null);
     }
 
@@ -1851,10 +1853,13 @@ internal class ConnectInterface {
     }
 
     /// <summary>
-    /// Saves connection settings (address, port, username) to persistent storage.
+    /// Saves connection settings (address if non-null, port, username) to persistent storage.
     /// </summary>
-    private void SaveConnectionSettings(string address, int port, string username) {
-        _modSettings.ConnectAddress = address;
+    private void SaveConnectionSettings(string? address, int port, string username) {
+        if (address != null) {
+            _modSettings.ConnectAddress = address;
+        }
+
         _modSettings.ConnectPort = port;
         _modSettings.Username = username;
         _modSettings.Save();

--- a/SSMP/Util/FileUtil.cs
+++ b/SSMP/Util/FileUtil.cs
@@ -88,10 +88,15 @@ internal static class FileUtil {
     }
 
     /// <summary>
-    /// Get the path of the SSMP config directory within Silksong's config directory.
+    /// Get the path of the SSMP config directory within Silksong's config directory. If we are on desktop, this uses
+    /// the save directory from the 'platform', which includes an intermediate directory for the "UserId".
     /// </summary>
     /// <returns>The path as a string.</returns>
     public static string GetConfigPath() {
+        if (Platform.Current is DesktopPlatform desktopPlatform) {
+            return Path.Combine(desktopPlatform.saveDirPath, "ssmp");
+        }
+
         return Path.Combine(Application.persistentDataPath, "ssmp");
     }
 


### PR DESCRIPTION
Improves saving mod settings by saving the file to disk when the game is quit and when the "host" button is pressed in the UI (in addition to the already existing saving when the "connect" button is pressed).

Moves the `ssmp` directory from the persistent data path to a directory down based on the desktop platform's so called "user ID" (for example: `.../unity3d/Team Cherry/Hollow Knight Silksong/{id}/ssmp/modsettings.json`). For Steam this means that settings are saved per-user instead of per-device. Likely this is similarly handled for other platforms (GoG, Xbox Store), but has not been tested. Fallback in case this functionality cannot be used is the persistent data path as previously implemented.