### PR TITLE
Fix various issues with matchmaking lobbies

### DIFF
--- a/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
+++ b/MMS/Services/Matchmaking/JoinSessionCoordinator.cs
@@ -122,7 +122,7 @@ public sealed class JoinSessionCoordinator {
     /// <param name="port">The external port observed by the server.</param>
     /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
     public async Task SetDiscoveredPortAsync(string token, int port, CancellationToken cancellationToken = default) {
-        if (!_store.TryGetDiscoveryMetadata(token, out var metadata) || metadata == null)
+        if (!_store.TryGetDiscoveryMetadata(token, out var metadata))
             return;
 
         if (!_store.TrySetDiscoveredPort(token, port))
@@ -390,9 +390,8 @@ public sealed class JoinSessionCoordinator {
         // Matchmaking lobbies store ConnectionData as "IP:Port".
         // Steam lobbies are filtered out at session creation.
         var hostIp = lobby.ConnectionData.Split(':')[0];
-        var startTimeMs = DateTimeOffset.UtcNow
-                                        .AddMilliseconds(MatchmakingProtocol.PunchTimingOffsetMs)
-                                        .ToUnixTimeMilliseconds();
+        var serverTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var startTimeMs = serverTimeMs + MatchmakingProtocol.PunchTimingOffsetMs;
 
         try {
             var hostSent = await JoinSessionMessenger.SendStartPunchToHostAsync(
@@ -402,7 +401,8 @@ public sealed class JoinSessionCoordinator {
                 session.ClientExternalPort.Value,
                 lobby.ExternalPort.Value,
                 startTimeMs,
-                cancellationToken
+                cancellationToken,
+                serverTimeMs
             );
             if (!hostSent) {
                 await FailJoinSessionAsync(joinId, "host_unreachable", cancellationToken);
@@ -414,7 +414,8 @@ public sealed class JoinSessionCoordinator {
                 lobby.ExternalPort.Value,
                 hostIp,
                 startTimeMs,
-                cancellationToken
+                cancellationToken,
+                serverTimeMs
             );
             if (!clientSent) {
                 await FailJoinSessionAsync(joinId, "client_disconnected", cancellationToken);

--- a/MMS/Services/Matchmaking/JoinSessionMessenger.cs
+++ b/MMS/Services/Matchmaking/JoinSessionMessenger.cs
@@ -90,7 +90,8 @@ public sealed class JoinSessionMessenger(LobbyService lobbyService) {
         int hostPort,
         string hostIp,
         long startTimeMs,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        long serverTimeMs
     ) {
         if (session.ClientWebSocket is not { State: WebSocketState.Open } ws)
             return false;
@@ -102,7 +103,8 @@ public sealed class JoinSessionMessenger(LobbyService lobbyService) {
                 joinId = session.JoinId,
                 hostIp,
                 hostPort,
-                startTimeMs
+                startTimeMs,
+                serverTimeMs
             },
             cancellationToken
         );
@@ -121,7 +123,8 @@ public sealed class JoinSessionMessenger(LobbyService lobbyService) {
         int clientPort,
         int hostPort,
         long startTimeMs,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        long serverTimeMs
     ) {
         if (lobby.HostWebSocket is not { State: WebSocketState.Open } hostWs)
             return false;
@@ -134,7 +137,8 @@ public sealed class JoinSessionMessenger(LobbyService lobbyService) {
                 clientIp,
                 clientPort,
                 hostPort,
-                startTimeMs
+                startTimeMs,
+                serverTimeMs
             },
             cancellationToken
         );

--- a/SSMP/Game/SteamManager.cs
+++ b/SSMP/Game/SteamManager.cs
@@ -72,6 +72,11 @@ public static class SteamManager {
     private static ELobbyType _pendingLobbyType;
 
     /// <summary>
+    /// The visibility type of the currently active lobby.
+    /// </summary>
+    private static ELobbyType _currentLobbyType = DefaultLobbyType;
+
+    /// <summary>
     /// Callback timer interval in milliseconds (~60Hz).
     /// </summary>
     private const int CallbackIntervalMs = 17;
@@ -86,7 +91,6 @@ public static class SteamManager {
     /// </summary>
     private const string LobbyKeyName = "name";
     private const string LobbyKeyVersion = "version";
-
     /// <summary>
     /// Cached mod version string from assembly metadata.
     /// </summary>
@@ -229,6 +233,7 @@ public static class SteamManager {
         var lobbyToLeave = CurrentLobbyId;
         CurrentLobbyId = NilLobbyId;
         IsHostingLobby = false;
+        _currentLobbyType = DefaultLobbyType;
 
         // Clear Rich Presence so friends no longer see "Join Game" option
         SteamFriends.ClearRichPresence();
@@ -254,6 +259,43 @@ public static class SteamManager {
 
         Logger.Info($"Opening Steam invite dialog for lobby: {CurrentLobbyId}");
         SteamFriends.ActivateGameOverlayInviteDialog(CurrentLobbyId);
+    }
+
+    /// <summary>
+    /// Marks the hosted lobby as ready or not ready for inbound players.
+    /// Steam join links stay disabled until the host is actually listening.
+    /// </summary>
+    /// <param name="isReady">Whether the host has finished startup and can accept joins.</param>
+    public static void SetLobbyReady(bool isReady) {
+        if (!IsInitialized) {
+            Logger.Warn("Cannot update Steam lobby readiness: Steam is not initialized");
+            return;
+        }
+
+        if (CurrentLobbyId == NilLobbyId || !IsHostingLobby) {
+            Logger.Warn("Cannot update Steam lobby readiness: no hosted lobby is active");
+            return;
+        }
+
+        SteamMatchmaking.SetLobbyJoinable(CurrentLobbyId, isReady);
+
+        // Clear first so stale connect keys are not left around while the host is still booting.
+        SteamFriends.ClearRichPresence();
+
+        if (!isReady) {
+            SteamFriends.SetRichPresence("status", "Starting Lobby");
+            Logger.Info($"Steam lobby {CurrentLobbyId} marked not ready");
+            return;
+        }
+
+        if (_currentLobbyType != ELobbyType.k_ELobbyTypePrivate) {
+            SteamFriends.SetRichPresence("connect", CurrentLobbyId.m_SteamID.ToString());
+            SteamFriends.SetRichPresence("status", "In Lobby");
+            Logger.Info($"Steam lobby {CurrentLobbyId} marked ready with connect={CurrentLobbyId.m_SteamID}");
+        } else {
+            SteamFriends.SetRichPresence("status", "In Private Lobby");
+            Logger.Info($"Steam private lobby {CurrentLobbyId} marked ready");
+        }
     }
 
     /// <summary>
@@ -347,6 +389,7 @@ public static class SteamManager {
         var lobbyId = new CSteamID(callback.m_ulSteamIDLobby);
         CurrentLobbyId = lobbyId;
         IsHostingLobby = true;
+        _currentLobbyType = _pendingLobbyType;
 
         Logger.Info($"Steam lobby created successfully: {lobbyId}");
 
@@ -357,19 +400,7 @@ public static class SteamManager {
         var steamName = SteamFriends.GetPersonaName();
         SteamMatchmaking.SetLobbyData(lobbyId, LobbyKeyName, $"{steamName}'s Lobby");
         SteamMatchmaking.SetLobbyData(lobbyId, LobbyKeyVersion, ModVersion);
-
-        // Set Rich Presence based on lobby type
-        // Private lobbies: NO connect key (truly invite-only, no "Join Game" button)
-        // Public/Friends: Set connect key so friends can "Join Game" from Steam
-        if (_pendingLobbyType != ELobbyType.k_ELobbyTypePrivate) {
-            SteamFriends.SetRichPresence("connect", lobbyId.m_SteamID.ToString());
-            SteamFriends.SetRichPresence("status", "In Lobby");
-            Logger.Info($"Rich Presence set with connect={lobbyId.m_SteamID}");
-        } else {
-            // Private lobby: set status only, use /invite command to send invites
-            SteamFriends.SetRichPresence("status", "In Private Lobby");
-            Logger.Info("Private lobby - use /invite to send Steam invites");
-        }
+        SetLobbyReady(false);
 
         // Fire event for listeners
         LobbyCreatedEvent?.Invoke(lobbyId, username ?? "Unknown");

--- a/SSMP/Networking/Matchmaking/Host/MmsHostSessionService.cs
+++ b/SSMP/Networking/Matchmaking/Host/MmsHostSessionService.cs
@@ -41,6 +41,11 @@ internal sealed class MmsHostSessionService : IDisposable {
     /// </summary>
     private string? _currentLobbyId;
 
+    /// <summary>
+    /// The most recent host discovery token returned by MMS for the active matchmaking lobby.
+    /// </summary>
+    private string? _currentHostDiscoveryToken;
+
     /// <summary>MMS lobby keep-alive timer.</summary>
     private Timer? _heartbeatTimer;
 
@@ -60,7 +65,7 @@ internal sealed class MmsHostSessionService : IDisposable {
     /// <c>null</c> when no refresh is running.
     /// </summary>
     private CancellationTokenSource? _hostDiscoveryRefreshCts;
-    
+
     /// <summary>WebSocket handler that receives real-time MMS server events.</summary>
     public MmsWebSocketHandler WebSocket { get; }
 
@@ -130,7 +135,9 @@ internal sealed class MmsHostSessionService : IDisposable {
             );
 
             if (effectiveHostIpOverride != null) {
-                Logger.Info($"MmsHostSessionService: Using HostIpOverride {effectiveHostIpOverride} for lobby creation.");
+                Logger.Info(
+                    $"MmsHostSessionService: Using HostIpOverride {effectiveHostIpOverride} for lobby creation."
+                );
                 if (isPublic && NetworkingUtil.IsPrivateIpv4(effectiveHostIpOverride)) {
                     Logger.Warn(
                         $"MmsHostSessionService: Public lobby is advertising private HostIpOverride {effectiveHostIpOverride}. " +
@@ -140,7 +147,9 @@ internal sealed class MmsHostSessionService : IDisposable {
             }
 
             if (effectiveHostLanIpOverride != null)
-                Logger.Info($"MmsHostSessionService: Using HostLanIpOverride {effectiveHostLanIpOverride} for lobby creation.");
+                Logger.Info(
+                    $"MmsHostSessionService: Using HostLanIpOverride {effectiveHostLanIpOverride} for lobby creation."
+                );
 
             var jsonString = MmsJsonParser.FormatCreateLobbyJson(
                 hostPort,
@@ -273,6 +282,26 @@ internal sealed class MmsHostSessionService : IDisposable {
     }
 
     /// <summary>
+    /// Starts host UDP discovery using the token returned at lobby creation time, if one exists.
+    /// This primes MMS with the host's live socket mapping before any join arrives.
+    /// </summary>
+    /// <param name="sendRawAction">Callback that writes raw bytes through the host's live UDP socket.</param>
+    public void StartInitialHostDiscoveryRefresh(Action<byte[], IPEndPoint> sendRawAction) {
+        if (_disposed) throw new ObjectDisposedException(nameof(MmsHostSessionService));
+
+        var token = _currentHostDiscoveryToken;
+        if (string.IsNullOrEmpty(token)) {
+            Logger.Info(
+                "MmsHostSessionService: no initial host discovery token available; skipping startup discovery."
+            );
+            return;
+        }
+
+        Logger.Info("MmsHostSessionService: starting initial host discovery refresh.");
+        StartHostDiscoveryRefresh(token, sendRawAction);
+    }
+
+    /// <summary>
     /// Cancels the active UDP discovery refresh task, if any.
     /// Safe to call when no refresh is running.
     /// </summary>
@@ -297,12 +326,14 @@ internal sealed class MmsHostSessionService : IDisposable {
     /// <param name="gameVersion">Game version string for compatibility filtering.</param>
     /// <returns>A JSON string ready to POST to the MMS lobby endpoint.</returns>
     private static string BuildSteamLobbyJson(string steamLobbyId, bool isPublic, string gameVersion) =>
-        $"{{\"{MmsFields.ConnectionDataRequest}\":\"{JsonConvert.ToString(steamLobbyId)}\"," +
-        $"\"{MmsFields.IsPublicRequest}\":{isPublic.ToString().ToLower()}," +
-        $"\"{MmsFields.GameVersionRequest}\":\"{JsonConvert.ToString(gameVersion)}\"," +
-        $"\"{MmsFields.LobbyTypeRequest}\":\"steam\"}}";
-
-
+        JsonConvert.SerializeObject(
+            new {
+                ConnectionData = steamLobbyId,
+                IsPublic       = isPublic,
+                GameVersion    = gameVersion,
+                LobbyType      = "steam"
+            });
+    
     /// <summary>
     /// Captures the current session token and lobby ID, then clears both fields.
     /// Called during <see cref="CloseLobby"/> to ensure the delete request uses
@@ -318,6 +349,7 @@ internal sealed class MmsHostSessionService : IDisposable {
         var snapshot = (_hostToken!, _currentLobbyId);
         _hostToken = null;
         _currentLobbyId = null;
+        _currentHostDiscoveryToken = null;
         return snapshot;
     }
 
@@ -355,6 +387,7 @@ internal sealed class MmsHostSessionService : IDisposable {
 
             _hostToken = hostToken;
             _currentLobbyId = lobbyId;
+            _currentHostDiscoveryToken = hostDiscoveryToken;
             _heartbeatFailureCount = 0;
             StartHeartbeat();
         }

--- a/SSMP/Networking/Matchmaking/Host/MmsHostSessionService.cs
+++ b/SSMP/Networking/Matchmaking/Host/MmsHostSessionService.cs
@@ -332,8 +332,9 @@ internal sealed class MmsHostSessionService : IDisposable {
                 IsPublic       = isPublic,
                 GameVersion    = gameVersion,
                 LobbyType      = "steam"
-            });
-    
+            }
+        );
+
     /// <summary>
     /// Captures the current session token and lobby ID, then clears both fields.
     /// Called during <see cref="CloseLobby"/> to ensure the delete request uses

--- a/SSMP/Networking/Matchmaking/Host/MmsWebSocketHandler.cs
+++ b/SSMP/Networking/Matchmaking/Host/MmsWebSocketHandler.cs
@@ -44,7 +44,7 @@ internal sealed class MmsWebSocketHandler : IDisposable, IAsyncDisposable {
 
     /// <summary>
     /// Raised when MMS signals both sides to start simultaneous hole-punch.
-    /// Arguments: joinId, clientIp, clientPort, hostPort, startTimeMs.
+    /// Arguments: joinId, clientIp, clientPort, hostPort, serverTimeMs, startTimeMs.
     /// <para>
     /// Handlers are always invoked on the <see cref="SynchronizationContext"/> that was
     /// active when this handler was constructed (typically the Unity main thread).
@@ -59,7 +59,7 @@ internal sealed class MmsWebSocketHandler : IDisposable, IAsyncDisposable {
     /// order, but may execute across different frames.
     /// </para>
     /// </summary>
-    public event Action<string, string, int, int, long>? StartPunchRequested;
+    public event Action<string, string, int, int, long, long>? StartPunchRequested;
 
     /// <summary>Raised on mapping confirmation. Marshaled to construction thread.</summary>
     public event Action? HostMappingReceived;
@@ -351,17 +351,19 @@ internal sealed class MmsWebSocketHandler : IDisposable, IAsyncDisposable {
         var clientIp = MmsJsonParser.ExtractValue(message, MmsFields.ClientIp);
         var clientPortStr = MmsJsonParser.ExtractValue(message, MmsFields.ClientPort);
         var hostPortStr = MmsJsonParser.ExtractValue(message, MmsFields.HostPort);
+        var serverTimeStr = MmsJsonParser.ExtractValue(message, MmsFields.ServerTimeMs);
         var startTimeStr = MmsJsonParser.ExtractValue(message, MmsFields.StartTimeMs);
 
         if (joinId == null ||
             clientIp == null ||
             !int.TryParse(clientPortStr, out var clientPort) ||
             !int.TryParse(hostPortStr, out var hostPort) ||
+            !long.TryParse(serverTimeStr, out var serverTimeMs) ||
             !long.TryParse(startTimeStr, out var startTimeMs))
             return;
 
         Logger.Info($"MmsWebSocketHandler: {MmsActions.StartPunch} for join {joinId} -> {clientIp}:{clientPort}");
-        eq.Enqueue(() => StartPunchRequested?.Invoke(joinId, clientIp, clientPort, hostPort, startTimeMs));
+        eq.Enqueue(() => StartPunchRequested?.Invoke(joinId, clientIp, clientPort, hostPort, serverTimeMs, startTimeMs));
     }
 
     /// <summary>

--- a/SSMP/Networking/Matchmaking/Join/MmsJoinCoordinator.cs
+++ b/SSMP/Networking/Matchmaking/Join/MmsJoinCoordinator.cs
@@ -115,6 +115,8 @@ internal sealed class MmsJoinCoordinator {
         DiscoverySession discovery,
         Action<string> onJoinFailed
     ) {
+        discovery.ObserveServerTime(message);
+
         var action = MmsJsonParser.ExtractValue(message, MmsFields.Action);
         if (action == null) {
             Logger.Debug("MmsWebSocketHandler: invalid message, no defined action");
@@ -173,7 +175,9 @@ internal sealed class MmsJoinCoordinator {
             return null;
         }
 
-        await DelayUntilAsync(joinStart.StartTimeMs, timeoutCts.Token);
+        var localNowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var estimatedServerOffsetMs = discovery.MinObservedServerOffsetMs ?? (localNowMs - joinStart.ServerTimeMs);
+        await DelayUntilAsync(joinStart.StartTimeMs, estimatedServerOffsetMs, timeoutCts.Token);
         return joinStart;
     }
 
@@ -209,9 +213,12 @@ internal sealed class MmsJoinCoordinator {
     /// is far in the future, the delay will simply block until <paramref name="ct"/> fires.
     /// </summary>
     /// <param name="targetUnixMs">Target time expressed as milliseconds since the Unix epoch (UTC).</param>
+    /// <param name="estimatedServerOffsetMs">Best estimate of local-minus-MMS clock offset in milliseconds.</param>
     /// <param name="ct">Cancellation token that can abort the wait early.</param>
-    private static async Task DelayUntilAsync(long targetUnixMs, CancellationToken ct) {
-        var delayMs = targetUnixMs - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    private static async Task DelayUntilAsync(long targetUnixMs, long estimatedServerOffsetMs, CancellationToken ct) {
+        var localNowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var targetLocalTimeMs = targetUnixMs + estimatedServerOffsetMs;
+        var delayMs = targetLocalTimeMs - localNowMs;
         if (delayMs > 0) await Task.Delay(TimeSpan.FromMilliseconds(delayMs), ct);
     }
 
@@ -236,6 +243,27 @@ internal sealed class MmsJoinCoordinator {
         /// if no discovery is active.
         /// </summary>
         public CancellationTokenSource? Cts;
+
+        /// <summary>
+        /// Best observed mapping from MMS server time to local UTC clock.
+        /// Uses the minimum observed local-minus-server delta to reduce network-latency bias.
+        /// </summary>
+        public long? MinObservedServerOffsetMs { get; private set; }
+
+        /// <summary>
+        /// Updates the best-known server-to-local clock offset from a message that includes server time.
+        /// </summary>
+        public void ObserveServerTime(string message) {
+            var serverTimeStr = MmsJsonParser.ExtractValue(message, MmsFields.ServerTimeMs);
+            if (!long.TryParse(serverTimeStr, out var serverTimeMs)) {
+                return;
+            }
+
+            var offsetMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - serverTimeMs;
+            MinObservedServerOffsetMs = MinObservedServerOffsetMs.HasValue
+                ? System.Math.Min(MinObservedServerOffsetMs.Value, offsetMs)
+                : offsetMs;
+        }
 
         /// <summary>Cancels <see cref="Cts"/> without disposing it.</summary>
         public void Cancel() {

--- a/SSMP/Networking/Matchmaking/MmsClient.cs
+++ b/SSMP/Networking/Matchmaking/MmsClient.cs
@@ -133,6 +133,10 @@ internal sealed class MmsClient {
     public void StartHostDiscoveryRefresh(string hostDiscoveryToken, Action<byte[], IPEndPoint> sendRawAction) =>
         HostSession.StartHostDiscoveryRefresh(hostDiscoveryToken, sendRawAction);
 
+    /// <summary>Starts startup-time host UDP discovery using the current lobby's initial token, if present.</summary>
+    public void StartInitialHostDiscoveryRefresh(Action<byte[], IPEndPoint> sendRawAction) =>
+        HostSession.StartInitialHostDiscoveryRefresh(sendRawAction);
+
     /// <summary>Stops active host discovery refresh loop.</summary>
     public void StopHostDiscoveryRefresh() => HostSession.StopHostDiscoveryRefresh();
 

--- a/SSMP/Networking/Matchmaking/Parsing/MmsResponseParser.cs
+++ b/SSMP/Networking/Matchmaking/Parsing/MmsResponseParser.cs
@@ -28,11 +28,11 @@ internal static class MmsResponseParser {
         out string? hostDiscoveryToken
     ) {
         var root = ParseJsonObject(response);
-        lobbyId             = root?.Value<string>(MmsFields.ConnectionData);
-        hostToken           = root?.Value<string>(MmsFields.HostToken);
-        lobbyName           = root?.Value<string>(MmsFields.LobbyName);
-        lobbyCode           = root?.Value<string>(MmsFields.LobbyCode);
-        hostDiscoveryToken  = root?.Value<string>(MmsFields.HostDiscoveryToken);
+        lobbyId            = root?.Value<string>(MmsFields.ConnectionData);
+        hostToken          = root?.Value<string>(MmsFields.HostToken);
+        lobbyName          = root?.Value<string>(MmsFields.LobbyName);
+        lobbyCode          = root?.Value<string>(MmsFields.LobbyCode);
+        hostDiscoveryToken = root?.Value<string>(MmsFields.HostDiscoveryToken);
 
         return lobbyId != null && hostToken != null && lobbyName != null && lobbyCode != null;
     }
@@ -47,8 +47,8 @@ internal static class MmsResponseParser {
             return null;
         }
 
-        var connectionData   = root.Value<string>(MmsFields.ConnectionData);
-        var lobbyTypeString  = root.Value<string>(MmsFields.LobbyType);
+        var connectionData  = root.Value<string>(MmsFields.ConnectionData);
+        var lobbyTypeString = root.Value<string>(MmsFields.LobbyType);
 
         if (connectionData == null || lobbyTypeString == null) {
             return null;
@@ -86,30 +86,34 @@ internal static class MmsResponseParser {
             return null;
         }
 
-        var hostIp   = root.Value<string>(MmsFields.HostIp);
-        var hostPort = root.Value<int?>(MmsFields.HostPort);
-        var startTime = root.Value<long?>(MmsFields.StartTimeMs);
+        var hostIp     = root.Value<string>(MmsFields.HostIp);
+        var hostPort   = root.Value<int?>(MmsFields.HostPort);
+        var serverTime = root.Value<long?>(MmsFields.ServerTimeMs);
+        var startTime  = root.Value<long?>(MmsFields.StartTimeMs);
 
-        if (hostIp == null || hostPort == null || startTime == null) {
+        if (hostIp == null || hostPort == null || serverTime == null || startTime == null) {
             return null;
         }
 
         return new MatchmakingJoinStartResult {
-            HostIp      = hostIp,
-            HostPort    = hostPort.Value,
-            StartTimeMs = startTime.Value
+            HostIp       = hostIp,
+            HostPort     = hostPort.Value,
+            ServerTimeMs = serverTime.Value,
+            StartTimeMs  = startTime.Value
         };
     }
 
     /// <summary>Normalizes lobby-list payloads so callers can always iterate a JSON array.</summary>
     private static JArray ParseLobbiesAsArray(string response) {
         return JToken.Parse(response) switch {
-            JArray  array => array,
-            var other     => LogAndReturnEmpty(other)
+            JArray array => array,
+            var other => LogAndReturnEmpty(other)
         };
 
         static JArray LogAndReturnEmpty(JToken other) {
-            Logger.Debug($"MmsResponseParser: Unexpected lobby payload token type '{other.Type}', expected array or object.");
+            Logger.Debug(
+                $"MmsResponseParser: Unexpected lobby payload token type '{other.Type}', expected array or object."
+            );
             return [];
         }
     }

--- a/SSMP/Networking/Matchmaking/Protocol/MmsFields.cs
+++ b/SSMP/Networking/Matchmaking/Protocol/MmsFields.cs
@@ -81,9 +81,6 @@ internal static class MmsFields {
     /// <summary>The LAN IP address of the host (Request field).</summary>
     public const string HostLanIpRequest = "HostLanIp";
 
-    /// <summary>Opaque connection data (Request field).</summary>
-    public const string ConnectionDataRequest = "ConnectionData";
-
     /// <summary>The IP address of the client (Request field).</summary>
     public const string ClientIpRequest = "ClientIp";
 

--- a/SSMP/Networking/Matchmaking/Protocol/MmsModels.cs
+++ b/SSMP/Networking/Matchmaking/Protocol/MmsModels.cs
@@ -71,6 +71,9 @@ internal sealed class MatchmakingJoinStartResult {
     /// <summary>The resolved public port of the host.</summary>
     public required int HostPort { get; init; }
 
+    /// <summary>The MMS server time when the start-punch message was emitted.</summary>
+    public required long ServerTimeMs { get; init; }
+
     /// <summary>The Unix timestamp (ms) when both sides should start punching.</summary>
     public required long StartTimeMs { get; init; }
 }

--- a/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransportServer.cs
+++ b/SSMP/Networking/Transport/HolePunch/HolePunchEncryptedTransportServer.cs
@@ -53,6 +53,12 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
     /// </summary>
     private readonly ConcurrentDictionary<IPEndPoint, HolePunchEncryptedTransportClient> _clients;
 
+    /// <summary>
+    /// Best observed mapping from MMS server time to the host's local UTC clock.
+    /// Uses the minimum observed local-minus-server delta to reduce network-latency bias.
+    /// </summary>
+    private long? _minObservedServerOffsetMs;
+
     /// <inheritdoc />
     public event Action<IEncryptedTransportClient>? ClientConnectedEvent;
 
@@ -72,13 +78,14 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
             _mmsClient.HostSession.WebSocket.HostMappingReceived += OnHostMappingReceived;
             _mmsClient.HostSession.WebSocket.StartPunchRequested += OnStartPunchRequested;
         }
-        
+
         var socket = PreBoundSocket;
         PreBoundSocket = null;
-        
+
         _dtlsServer.Start(port, socket);
 
         _mmsClient?.StartWebSocketConnection();
+        _mmsClient?.StartInitialHostDiscoveryRefresh((data, endpoint) => _dtlsServer.SendRaw(data, endpoint));
     }
 
     /// <inheritdoc />
@@ -100,22 +107,30 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
     /// <summary>
     /// Called when MMS notifies us of a client needing punch-back.
     /// </summary>
-    private void OnStartPunchRequested(string joinId, string clientIp, int clientPort, int hostPort, long startTimeMs) {
+    private void OnStartPunchRequested(
+        string joinId,
+        string clientIp,
+        int clientPort,
+        int hostPort,
+        long serverTimeMs,
+        long startTimeMs
+    ) {
         _mmsClient?.StopHostDiscoveryRefresh();
+        ObserveServerTime(serverTimeMs);
         if (!IPAddress.TryParse(clientIp, out var ip)) {
             Logger.Warn($"HolePunch Server: Invalid client IP: {clientIp}");
             return;
         }
 
         // Run the PunchToClientAsync method asynchronously, but don't wait for the result
-        _ = PunchToClientAsync(new IPEndPoint(ip, clientPort), startTimeMs);
+        _ = PunchToClientAsync(new IPEndPoint(ip, clientPort), serverTimeMs, startTimeMs);
     }
 
     /// <inheritdoc />
     public void DisconnectClient(IEncryptedTransportClient client) {
         if (client is not HolePunchEncryptedTransportClient hpClient)
             return;
-        
+
         _dtlsServer.DisconnectClient(hpClient.EndPoint);
         _clients.TryRemove(hpClient.EndPoint, out _);
     }
@@ -124,21 +139,26 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
     /// Callback method for when data is received from a server client.
     /// </summary>
     private void OnClientDataReceived(DtlsServerClient dtlsClient, byte[] data, int length) {
-        var client = _clients.GetOrAdd(dtlsClient.EndPoint, _ => {
-            var newClient = new HolePunchEncryptedTransportClient(dtlsClient);
-            ClientConnectedEvent?.Invoke(newClient);
-            return newClient;
-        });
+        var client = _clients.GetOrAdd(
+            dtlsClient.EndPoint, _ => {
+                var newClient = new HolePunchEncryptedTransportClient(dtlsClient);
+                ClientConnectedEvent?.Invoke(newClient);
+                return newClient;
+            }
+        );
 
         client.RaiseDataReceived(data, length);
     }
-    
+
     /// <summary>
     /// Called when MMS asks the host to refresh its matchmaking mapping on the live UDP server socket.
     /// </summary>
     private void OnHostMappingRefreshRequested(string joinId, string hostDiscoveryToken, long serverTimeMs) {
         Logger.Info($"HolePunch Server: Refreshing host mapping for join {joinId}");
-        _mmsClient?.StartHostDiscoveryRefresh(hostDiscoveryToken, (data, endpoint) => _dtlsServer.SendRaw(data, endpoint));
+        ObserveServerTime(serverTimeMs);
+        _mmsClient?.StartHostDiscoveryRefresh(
+            hostDiscoveryToken, (data, endpoint) => _dtlsServer.SendRaw(data, endpoint)
+        );
     }
 
     /// <summary>
@@ -154,10 +174,13 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
     /// spaced <see cref="PunchPacketDelayMs"/> ms apart, starting at <paramref name="startTimeMs"/>.
     /// Exceptions are caught and logged rather than propagated, since this runs fire-and-forget.
     /// </summary>
-    private async Task PunchToClientAsync(IPEndPoint clientEndpoint, long startTimeMs) {
+    private async Task PunchToClientAsync(IPEndPoint clientEndpoint, long serverTimeMs, long startTimeMs) {
         try {
             Logger.Debug($"HolePunch Server: Punching to client at {clientEndpoint}");
-            var delay = startTimeMs - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var localNowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var estimatedServerOffsetMs = _minObservedServerOffsetMs ?? (localNowMs - serverTimeMs);
+            var targetLocalTimeMs = startTimeMs + estimatedServerOffsetMs;
+            var delay = targetLocalTimeMs - localNowMs;
             if (delay > 0) await Task.Delay(TimeSpan.FromMilliseconds(delay));
 
             for (var i = 0; i < PunchPacketCount; i++) {
@@ -169,5 +192,15 @@ internal class HolePunchEncryptedTransportServer : IEncryptedTransportServer {
         } catch (Exception ex) {
             Logger.Error($"HolePunch Server: Punch to {clientEndpoint} failed – {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Updates the best-known MMS-server-to-local clock offset.
+    /// </summary>
+    private void ObserveServerTime(long serverTimeMs) {
+        var offsetMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - serverTimeMs;
+        _minObservedServerOffsetMs = _minObservedServerOffsetMs.HasValue
+            ? System.Math.Min(_minObservedServerOffsetMs.Value, offsetMs)
+            : offsetMs;
     }
 }

--- a/SSMP/Ui/ConnectInterface.cs
+++ b/SSMP/Ui/ConnectInterface.cs
@@ -476,6 +476,16 @@ internal class ConnectInterface {
     // ReSharper disable once NotAccessedField.Local
     private IButtonComponent? _joinFriendButton;
 
+    /// <summary>
+    /// Steam lobby ID for a newly created hosted Steam lobby that still needs post-start finalization.
+    /// </summary>
+    private string? _pendingHostedSteamLobbyId;
+
+    /// <summary>
+    /// Whether the pending hosted Steam lobby should be registered with MMS after the host is ready.
+    /// </summary>
+    private bool _pendingHostedSteamLobbyIsPublic;
+
     // Direct IP tab components
     /// <summary>
     /// Input field for the server IP address.
@@ -531,6 +541,11 @@ internal class ConnectInterface {
     /// If non-null, indicates the Lobby ID we should retry connecting to once if a hole punch times out.
     /// </summary>
     private string? _pendingHolePunchRetryLobbyId;
+
+    /// <summary>
+    /// Whether a matchmaking lobby join is already in progress.
+    /// </summary>
+    private bool _isLobbyJoinInProgress;
 
     /// <summary>
     /// Public accessor for the MMS client.
@@ -717,7 +732,6 @@ internal class ConnectInterface {
     /// Subscribes to Steam lobby-related events if Steam is available.
     /// </summary>
     private void SubscribeToSteamEvents() {
-        SteamManager.LobbyCreatedEvent += OnSteamLobbyCreated;
         SteamManager.LobbyListReceivedEvent += OnLobbyListReceived;
         SteamManager.LobbyJoinedEvent += OnLobbyJoined;
     }
@@ -1193,6 +1207,11 @@ internal class ConnectInterface {
             return;
         }
 
+        if (_isLobbyJoinInProgress) {
+            ShowFeedback(Color.yellow, "Already connecting...");
+            return;
+        }
+
         if (!ValidateUsername(out var username)) {
             return;
         }
@@ -1206,6 +1225,7 @@ internal class ConnectInterface {
         // Arm the one-time retry for a hole-punch failure
         _pendingHolePunchRetryLobbyId = lobbyId;
 
+        SetLobbyJoinInProgress();
         ShowFeedback(Color.yellow, "Connecting...");
         MonoBehaviourUtil.Instance.StartCoroutine(JoinLobbyCoroutine(lobbyId, username));
     }
@@ -1226,6 +1246,7 @@ internal class ConnectInterface {
 
         if (!task.IsCompletedSuccessfully) {
             CleanupHolePunchSocket(holePunchSocket);
+            ResetConnectionButtons();
             Logger.Error(
                 $"ConnectInterface: JoinLobbyAsync failed: {task.Exception?.GetBaseException().Message ?? "cancelled"}"
             );
@@ -1236,6 +1257,7 @@ internal class ConnectInterface {
         var lobbyInfo = task.Result;
         if (lobbyInfo == null) {
             CleanupHolePunchSocket(holePunchSocket);
+            ResetConnectionButtons();
 
             if (MmsClient.LastMatchmakingError == MatchmakingError.UpdateRequired) {
                 ActivateMatchmakingVersionBlock();
@@ -1254,10 +1276,11 @@ internal class ConnectInterface {
         // Handle connection based on lobby type
         if (lobbyType == PublicLobbyType.Steam) {
             CleanupHolePunchSocket(holePunchSocket);
-            ConnectToSteamLobby(connectionData, username);
+            ConnectToSteamLobby(connectionData);
         } else {
             if (string.IsNullOrEmpty(joinId)) {
                 CleanupHolePunchSocket(holePunchSocket);
+                ResetConnectionButtons();
                 ShowFeedback(Color.red, "Lobby not found, offline, or join failed");
                 yield break;
             }
@@ -1271,6 +1294,7 @@ internal class ConnectInterface {
 
             if (!joinTask.IsCompletedSuccessfully) {
                 CleanupHolePunchSocket(holePunchSocket);
+                ResetConnectionButtons();
                 Logger.Error(
                     $"ConnectInterface: CoordinateMatchmakingJoinAsync failed: {joinTask.Exception?.GetBaseException().Message ?? "cancelled"}"
                 );
@@ -1281,6 +1305,7 @@ internal class ConnectInterface {
             var joinStart = joinTask.Result;
             if (joinStart == null) {
                 CleanupHolePunchSocket(holePunchSocket);
+                ResetConnectionButtons();
 
                 if (MmsClient.LastMatchmakingError == MatchmakingError.UpdateRequired) {
                     ActivateMatchmakingVersionBlock();
@@ -1371,46 +1396,42 @@ internal class ConnectInterface {
         return;
 
         // Subscribe to lobby created event (one-time)
-        void OnLobbyCreatedCallback(CSteamID steamLobbyId, string hostName) {
+        void OnLobbyCreatedCallback(CSteamID steamLobbyId, string _) {
             // Unsubscribe immediately
             SteamManager.LobbyCreatedEvent -= OnLobbyCreatedCallback;
 
-            // Only PUBLIC Steam lobbies register with MMS for browser visibility
-            // Private and Friends-Only lobbies use Steam's native discovery only
-            if (isPublic) {
-                MonoBehaviourUtil.Instance.StartCoroutine(
-                    RegisterSteamLobbyForBrowserCoroutine(steamLobbyId.m_SteamID.ToString(), username)
-                );
-            } else {
-                ShowFeedback(Color.green, "Steam lobby created!");
-                StartHostButtonPressed?.Invoke("0.0.0.0", 0, username, TransportType.Steam, null);
-            }
+            _pendingHostedSteamLobbyId = steamLobbyId.m_SteamID.ToString();
+            _pendingHostedSteamLobbyIsPublic = isPublic;
+
+            ShowFeedback(Color.yellow, "Steam lobby created. Starting host...");
+            StartHostButtonPressed?.Invoke("0.0.0.0", 0, username, TransportType.Steam, null);
         }
     }
 
     /// <summary>
-    /// Registers a public Steam lobby with MMS for browser visibility (no invite code).
+    /// Finalizes a hosted Steam lobby after the local host has fully connected.
+    /// Public lobbies are registered with MMS only after the Steam P2P server is actually live.
     /// </summary>
-    private IEnumerator RegisterSteamLobbyForBrowserCoroutine(
-        string steamLobbyId,
-        string username
-    ) {
-        var task = MmsClient.RegisterSteamLobbyAsync(
-            steamLobbyId,
-            isPublic: true,
-            gameVersion: Application.version
-        );
+    private IEnumerator FinalizeHostedSteamLobbyCoroutine(string steamLobbyId, bool isPublic) {
+        if (isPublic) {
+            var task = MmsClient.RegisterSteamLobbyAsync(
+                steamLobbyId,
+                isPublic: true,
+                gameVersion: Application.version
+            );
 
-        yield return new WaitUntil(() => task.IsCompleted);
+            yield return new WaitUntil(() => task.IsCompleted);
 
-        // Don't show invite code for Steam lobbies - they use Steam's native join flow
-        if (task.Result == null) {
-            ShowFeedback(Color.yellow, "Steam lobby created (browser listing failed)");
+            if (!task.IsCompletedSuccessfully || task.Result == null) {
+                ShowFeedback(Color.yellow, "Steam lobby created (browser listing failed)");
+            } else {
+                ShowFeedback(Color.green, "Steam lobby created!");
+            }
         } else {
             ShowFeedback(Color.green, "Steam lobby created!");
         }
 
-        StartHostButtonPressed?.Invoke("0.0.0.0", 0, username, TransportType.Steam, null);
+        SteamManager.SetLobbyReady(true);
     }
 
 
@@ -1695,20 +1716,6 @@ internal class ConnectInterface {
     #region Steam Event Callbacks
 
     /// <summary>
-    /// Called when a Steam lobby is successfully created.
-    /// Displays success message and triggers server hosting.
-    /// </summary>
-    /// <param name="lobbyId">The unique Steam ID of the created lobby.</param>
-    /// <param name="username">The username of the lobby host.</param>
-    private void OnSteamLobbyCreated(CSteamID lobbyId, string username) {
-        Logger.Info($"Lobby created: {lobbyId}");
-        ShowFeedback(Color.green, "Lobby created! Friends can join via Steam overlay.");
-
-        // Start hosting with Steam transport (port 0 as it's not used for Steam P2P)
-        StartHostButtonPressed?.Invoke("", 0, username, TransportType.Steam, null);
-    }
-
-    /// <summary>
     /// Called when the list of available Steam lobbies is received.
     /// Auto-joins the first lobby if any are found.
     /// </summary>
@@ -1747,14 +1754,20 @@ internal class ConnectInterface {
     /// <summary>
     /// Handles connection to a Steam lobby.
     /// </summary>
-    private void ConnectToSteamLobby(string connectionData, string username) {
+    private void ConnectToSteamLobby(string connectionData) {
         if (!SteamManager.IsInitialized) {
             ShowFeedback(Color.red, "Steam is not initialized");
             return;
         }
 
-        ShowFeedback(Color.green, "Joining Steam lobby...");
-        ConnectButtonPressed?.Invoke(connectionData, 0, username, TransportType.Steam, null);
+        if (!ulong.TryParse(connectionData, out var steamLobbyId)) {
+            ShowFeedback(Color.red, "Invalid Steam lobby ID.");
+            Logger.Warn($"ConnectInterface: MMS returned invalid Steam lobby ID '{connectionData}'");
+            return;
+        }
+
+        ShowFeedback(Color.yellow, "Joining Steam lobby...");
+        SteamManager.JoinLobby(new CSteamID(steamLobbyId));
     }
 
     #endregion
@@ -1766,6 +1779,16 @@ internal class ConnectInterface {
     /// Resets UI state and displays success message.
     /// </summary>
     public void OnSuccessfulConnect() {
+        if (SteamManager.IsHostingLobby && _pendingHostedSteamLobbyId != null) {
+            var steamLobbyId = _pendingHostedSteamLobbyId;
+            var isPublic = _pendingHostedSteamLobbyIsPublic;
+
+            _pendingHostedSteamLobbyId = null;
+            _pendingHostedSteamLobbyIsPublic = false;
+
+            MonoBehaviourUtil.Instance.StartCoroutine(FinalizeHostedSteamLobbyCoroutine(steamLobbyId, isPublic));
+        }
+
         ShowFeedback(Color.green, MsgConnected);
         ResetConnectionButtons();
     }
@@ -1797,8 +1820,6 @@ internal class ConnectInterface {
             return;
         }
 
-        ResetConnectionButtons();
-
         // If this was a timeout and we have a pending retry, consume it and re-run the full connect flow.
         if (_pendingHolePunchRetryLobbyId != null && result.Reason == ConnectionFailedReason.TimedOut) {
             var lobbyIdToRetry = _pendingHolePunchRetryLobbyId;
@@ -1806,12 +1827,14 @@ internal class ConnectInterface {
 
             if (ValidateUsername(out var username)) {
                 Logger.Info($"ConnectInterface: Connection timed out. Retrying full join flow for lobby {lobbyIdToRetry} once.");
+                SetLobbyJoinInProgress();
                 ShowFeedback(Color.yellow, "Connection timed out. Retrying...");
                 MonoBehaviourUtil.Instance.StartCoroutine(JoinLobbyCoroutine(lobbyIdToRetry, username));
                 return;
             }
         }
 
+        ResetConnectionButtons();
         _pendingHolePunchRetryLobbyId = null;
 
         var message = GetFailureMessage(result);
@@ -1977,7 +2000,17 @@ internal class ConnectInterface {
     /// Resets the connection buttons to their default state after a connection attempt.
     /// </summary>
     private void ResetConnectionButtons() {
+        _isLobbyJoinInProgress = false;
         ConnectInterfaceHelpers.ResetConnectButtons(_directConnectButton, _lobbyConnectButton);
+    }
+
+    /// <summary>
+    /// Marks the matchmaking lobby join path as busy and disables duplicate join presses.
+    /// </summary>
+    private void SetLobbyJoinInProgress() {
+        _isLobbyJoinInProgress = true;
+        _lobbyConnectButton.SetText(ConnectingText);
+        _lobbyConnectButton.SetInteractable(false);
     }
 
     /// <summary>

--- a/SSMP/Ui/ConnectInterface.cs
+++ b/SSMP/Ui/ConnectInterface.cs
@@ -1826,7 +1826,9 @@ internal class ConnectInterface {
             _pendingHolePunchRetryLobbyId = null;
 
             if (ValidateUsername(out var username)) {
-                Logger.Info($"ConnectInterface: Connection timed out. Retrying full join flow for lobby {lobbyIdToRetry} once.");
+                Logger.Info(
+                    $"ConnectInterface: Connection timed out. Retrying full join flow for lobby {lobbyIdToRetry} once."
+                );
                 SetLobbyJoinInProgress();
                 ShowFeedback(Color.yellow, "Connection timed out. Retrying...");
                 MonoBehaviourUtil.Instance.StartCoroutine(JoinLobbyCoroutine(lobbyIdToRetry, username));
@@ -2103,15 +2105,19 @@ internal class ConnectInterface {
             return null;
 
         // Prefer LAN if available, using public as the fallback relay
-        if (preferLanFastPath &&
-            !string.IsNullOrEmpty(lanConnectionData) &&
-            TryParseConnectionData(lanConnectionData, out var lanIp, out var lanPort)) {
-            return new ConnectionInfo(
-                lanIp, lanPort, $"{publicIp}:{publicPort}", $"Connecting to LAN {lanIp}:{lanPort}..."
-            );
+        if (!preferLanFastPath || string.IsNullOrEmpty(lanConnectionData) ||
+            !TryParseConnectionData(lanConnectionData, out var lanIp, out var lanPort)) {
+            return new ConnectionInfo(publicIp, publicPort, null, $"Connecting to {publicIp}:{publicPort}...");
         }
 
-        return new ConnectionInfo(publicIp, publicPort, null, $"Connecting to {publicIp}:{publicPort}...");
+        // If the LAN endpoint resolves to one of this machine's own IPv4 addresses,
+        // the client and host are running on the same device. In that case, prefer
+        // loopback instead of connecting back through the LAN adapter, since some
+        // network setups handle that path inconsistently.
+        // The public endpoint is still kept as the fallback if the local attempt fails.
+        return NetworkingUtil.IsLocalInterfaceIpv4(lanIp)
+            ? new ConnectionInfo("127.0.0.1", lanPort, $"{publicIp}:{publicPort}", $"Connecting locally on 127.0.0.1:{lanPort}...")
+            : new ConnectionInfo(lanIp, lanPort, $"{publicIp}:{publicPort}", $"Connecting to LAN {lanIp}:{lanPort}...");
     }
 
     /// <summary>

--- a/SSMP/Util/NetworkingUtil.cs
+++ b/SSMP/Util/NetworkingUtil.cs
@@ -72,6 +72,17 @@ internal static class NetworkingUtil {
         return IPAddress.Any;
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is an IPv4 address assigned
+    /// to this machine, including loopback.
+    /// </summary>
+    public static bool IsLocalInterfaceIpv4(string? value) {
+        return TryNormalizeIpv4(value, out var normalized) &&
+               IPAddress.TryParse(normalized, out var address) &&
+               address.AddressFamily == AddressFamily.InterNetwork &&
+               IsLocalInterfaceAddress(address);
+    }
+
     #endregion
 
     #region Private Helpers


### PR DESCRIPTION
## What changed

### 1. MMS start-punch messages now include server time

The MMS server now sends `serverTimeMs` alongside `startTimeMs` in `start_punch`.

Client and host both record observed server-to-local clock offset and use that estimate when waiting for the coordinated punch start time.

Why:

- previously both sides assumed local clock ~= server clock
- if either machine clock drifted, punch packets could start too early or too late
- using MMS server time gives both sides a shared reference point

### 2. Host discovery can start immediately after lobby creation

The host now stores the initial discovery token returned by MMS and can start refreshing its UDP mapping as soon as the live server socket exists.

Why:

- previously MMS often did not learn the host's current external port until a join was already in progress
- that adds avoidable latency and increases the chance that the first join attempt races the mapping refresh
- priming the mapping on startup should make the first join more reliable

### 3. Steam lobbies are no longer advertised as ready too early

Steam lobby creation is now split into two phases:

1. create the native Steam lobby
2. wait for the host transport to come up, then finalize the lobby

During the gap, the lobby is marked not joinable and rich presence does not expose a connect target yet. After the host is actually ready, the lobby becomes joinable and public Steam lobbies are registered with MMS for browser visibility.

Why:

- previously a Steam lobby could expose a join path before the host was listening
- that creates misleading "Join Game" availability and early join failures
- the new sequence aligns Steam visibility with actual host readiness

### 4. Steam lobby join from MMS now uses Steam's native join flow

When MMS returns a Steam lobby entry, the client now parses the Steam lobby ID and calls `SteamManager.JoinLobby(...)` instead of treating the Steam lobby ID as a direct transport address.

Why:

- that path is more coherent with the rest of the Steam integration
- the actual transport connection should start after Steam confirms lobby join and ownership data is available

### 5. Matchmaking join UI is hardened against duplicate attempts

The lobby connect button now tracks whether a matchmaking join is already in progress and resets correctly on failure paths and retry handling.

Why:

- repeated button presses could overlap multiple join attempts

### 6. Same-PC matchmaking joins now route through loopback

When MMS returns a LAN fast-path endpoint and that endpoint belongs to one of the local machine's own interfaces, the client now canonicalizes the join target to `127.0.0.1:<actual host port>` instead of trying to connect back through the machine's LAN address.

Why:

- matchmaking hosts do not always bind to the default port; a local instance can end up on an ephemeral port
- same-PC joins are a weirder case than ordinary LAN joins and should use loopback explicitly
- routing two local game instances through localhost is more deterministic than relying on local NIC self-routing