### PR TITLE
Remove standalone server dependency on Unity

### DIFF
--- a/SSMP/Networking/Packet/PacketHandlerRegistry.cs
+++ b/SSMP/Networking/Packet/PacketHandlerRegistry.cs
@@ -99,6 +99,9 @@ internal class PacketHandlerRegistry<TPacketId, THandler>
 /// Interface for packet handler dispatchers.
 /// </summary>
 internal interface IPacketHandlerRegistryDispatcher {
+    /// <summary>
+    /// Dispatch this handler with the given action.
+    /// </summary>
     void Dispatch(Action action);
 }
 
@@ -106,6 +109,18 @@ internal interface IPacketHandlerRegistryDispatcher {
 /// Implementation of packet handler dispatcher to immediately invoke the handler directly for the server-side.
 /// </summary>
 internal class ServerPacketHandlerRegistryDispatcher : IPacketHandlerRegistryDispatcher {
+    /// <summary>
+    /// Publicly accessible static instance, since instances can not vary.
+    /// </summary>
+    public static readonly ServerPacketHandlerRegistryDispatcher Instance = new();
+
+    /// <summary>
+    /// Private constructor to prevent access outside of static instance.
+    /// </summary>
+    private ServerPacketHandlerRegistryDispatcher() {
+    }
+
+    /// <inheritdoc/>
     public void Dispatch(Action action) {
         action.Invoke();
     }
@@ -115,6 +130,18 @@ internal class ServerPacketHandlerRegistryDispatcher : IPacketHandlerRegistryDis
 /// Implementation of packet handler dispatcher to invoke the handler on Unity's main thread.
 /// </summary>
 internal class ClientPacketHandlerRegistryDispatcher : IPacketHandlerRegistryDispatcher {
+    /// <summary>
+    /// Publicly accessible static instance, since instances can not vary.
+    /// </summary>
+    public static readonly ClientPacketHandlerRegistryDispatcher Instance = new();
+
+    /// <summary>
+    /// Private constructor to prevent access outside of static instance.
+    /// </summary>
+    private ClientPacketHandlerRegistryDispatcher() {
+    }
+    
+    /// <inheritdoc/>
     public void Dispatch(Action action) {
         ThreadUtil.RunActionOnMainThread(action);
     }

--- a/SSMP/Networking/Packet/PacketHandlerRegistry.cs
+++ b/SSMP/Networking/Packet/PacketHandlerRegistry.cs
@@ -21,10 +21,13 @@ internal class PacketHandlerRegistry<TPacketId, THandler>
     private readonly Dictionary<TPacketId, THandler> _handlers = new();
     
     /// <summary>
-    /// Whether to dispatch handler invocations to the Unity main thread.
-    /// Client handlers typically need main thread dispatch; server handlers do not.
+    /// The dispatcher that handles how to call the packet handlers.
+    /// For clients, this will be the <see cref="ClientPacketHandlerRegistryDispatcher"/>, which invokes packet
+    /// handlers on the Unity main thread.
+    /// For servers, this will be the <see cref="ServerPacketHandlerRegistryDispatcher"/>, which directly invokes the
+    /// packet handlers.
     /// </summary>
-    private readonly bool _dispatchToMainThread;
+    private readonly IPacketHandlerRegistryDispatcher _dispatcher;
     
     /// <summary>
     /// Descriptive name for logging messages.
@@ -35,10 +38,10 @@ internal class PacketHandlerRegistry<TPacketId, THandler>
     /// Constructs a new packet handler registry.
     /// </summary>
     /// <param name="registryName">Name for logging purposes (e.g., "client update", "server connection").</param>
-    /// <param name="dispatchToMainThread">Whether to dispatch handler calls to Unity main thread.</param>
-    public PacketHandlerRegistry(string registryName, bool dispatchToMainThread) {
+    /// <param name="dispatcher">The dispatcher that handles how to call the packet handlers.</param>
+    public PacketHandlerRegistry(string registryName, IPacketHandlerRegistryDispatcher dispatcher) {
         _registryName = registryName;
-        _dispatchToMainThread = dispatchToMainThread;
+        _dispatcher = dispatcher;
     }
 
     /// <summary>
@@ -77,11 +80,7 @@ internal class PacketHandlerRegistry<TPacketId, THandler>
             return;
         }
 
-        if (_dispatchToMainThread) {
-            ThreadUtil.RunActionOnMainThread(() => SafeInvoke(packetId, handler, invoker));
-        } else {
-            SafeInvoke(packetId, handler, invoker);
-        }
+        _dispatcher.Dispatch(() => SafeInvoke(packetId, handler, invoker));
     }
 
     /// <summary>
@@ -93,5 +92,30 @@ internal class PacketHandlerRegistry<TPacketId, THandler>
         } catch (Exception e) {
             Logger.Error($"Exception occurred while executing {_registryName} packet handler for ID {packetId}:\n{e}");
         }
+    }
+}
+
+/// <summary>
+/// Interface for packet handler dispatchers.
+/// </summary>
+internal interface IPacketHandlerRegistryDispatcher {
+    void Dispatch(Action action);
+}
+
+/// <summary>
+/// Implementation of packet handler dispatcher to immediately invoke the handler directly for the server-side.
+/// </summary>
+internal class ServerPacketHandlerRegistryDispatcher : IPacketHandlerRegistryDispatcher {
+    public void Dispatch(Action action) {
+        action.Invoke();
+    }
+}
+
+/// <summary>
+/// Implementation of packet handler dispatcher to invoke the handler on Unity's main thread.
+/// </summary>
+internal class ClientPacketHandlerRegistryDispatcher : IPacketHandlerRegistryDispatcher {
+    public void Dispatch(Action action) {
+        ThreadUtil.RunActionOnMainThread(action);
     }
 }

--- a/SSMP/Networking/Packet/PacketManager.cs
+++ b/SSMP/Networking/Packet/PacketManager.cs
@@ -43,16 +43,16 @@ internal class PacketManager {
     #region Standard Packet Registries
 
     private readonly PacketHandlerRegistry<ClientUpdatePacketId, ClientPacketHandler> _clientUpdateRegistry = new(
-        "client update", true
+        "client update", new ClientPacketHandlerRegistryDispatcher()
     );
     private readonly PacketHandlerRegistry<ClientConnectionPacketId, ClientPacketHandler> _clientConnectionRegistry = new(
-        "client connection", true
+        "client connection", new ClientPacketHandlerRegistryDispatcher()
     );
     private readonly PacketHandlerRegistry<ServerUpdatePacketId, ServerPacketHandler> _serverUpdateRegistry = new(
-        "server update", false
+        "server update", new ServerPacketHandlerRegistryDispatcher()
     );
     private readonly PacketHandlerRegistry<ServerConnectionPacketId, ServerPacketHandler> _serverConnectionRegistry = new(
-        "server connection", false
+        "server connection", new ServerPacketHandlerRegistryDispatcher()
     );
     
     #endregion
@@ -268,7 +268,7 @@ internal class PacketManager {
     ) {
         if (!registryDict.TryGetValue(addonId, out var registry)) {
             registry = new PacketHandlerRegistry<byte, ClientPacketHandler>(
-                $"client addon {nameType} (Addon {addonId})", true
+                $"client addon {nameType} (Addon {addonId})", new ClientPacketHandlerRegistryDispatcher()
             );
             registryDict[addonId] = registry;
         }
@@ -323,7 +323,7 @@ internal class PacketManager {
     ) {
         if (!registryDict.TryGetValue(addonId, out var registry)) {
             registry = new PacketHandlerRegistry<byte, ServerPacketHandler>(
-                $"server addon {nameType} (Addon {addonId})", false
+                $"server addon {nameType} (Addon {addonId})", new ServerPacketHandlerRegistryDispatcher()
             );
             registryDict[addonId] = registry;
         }

--- a/SSMP/Networking/Packet/PacketManager.cs
+++ b/SSMP/Networking/Packet/PacketManager.cs
@@ -43,16 +43,16 @@ internal class PacketManager {
     #region Standard Packet Registries
 
     private readonly PacketHandlerRegistry<ClientUpdatePacketId, ClientPacketHandler> _clientUpdateRegistry = new(
-        "client update", new ClientPacketHandlerRegistryDispatcher()
+        "client update", ClientPacketHandlerRegistryDispatcher.Instance
     );
     private readonly PacketHandlerRegistry<ClientConnectionPacketId, ClientPacketHandler> _clientConnectionRegistry = new(
-        "client connection", new ClientPacketHandlerRegistryDispatcher()
+        "client connection", ClientPacketHandlerRegistryDispatcher.Instance
     );
     private readonly PacketHandlerRegistry<ServerUpdatePacketId, ServerPacketHandler> _serverUpdateRegistry = new(
-        "server update", new ServerPacketHandlerRegistryDispatcher()
+        "server update", ServerPacketHandlerRegistryDispatcher.Instance
     );
     private readonly PacketHandlerRegistry<ServerConnectionPacketId, ServerPacketHandler> _serverConnectionRegistry = new(
-        "server connection", new ServerPacketHandlerRegistryDispatcher()
+        "server connection", ServerPacketHandlerRegistryDispatcher.Instance
     );
     
     #endregion
@@ -268,7 +268,7 @@ internal class PacketManager {
     ) {
         if (!registryDict.TryGetValue(addonId, out var registry)) {
             registry = new PacketHandlerRegistry<byte, ClientPacketHandler>(
-                $"client addon {nameType} (Addon {addonId})", new ClientPacketHandlerRegistryDispatcher()
+                $"client addon {nameType} (Addon {addonId})", ClientPacketHandlerRegistryDispatcher.Instance
             );
             registryDict[addonId] = registry;
         }
@@ -323,7 +323,7 @@ internal class PacketManager {
     ) {
         if (!registryDict.TryGetValue(addonId, out var registry)) {
             registry = new PacketHandlerRegistry<byte, ServerPacketHandler>(
-                $"server addon {nameType} (Addon {addonId})", new ServerPacketHandlerRegistryDispatcher()
+                $"server addon {nameType} (Addon {addonId})", ServerPacketHandlerRegistryDispatcher.Instance
             );
             registryDict[addonId] = registry;
         }


### PR DESCRIPTION
Fixes #70.

Server-side code depended on Unity due to the packet handlers using a type from Unity, because client-side dispatches handlers to Unity's main thread.

This PR fixes the issue by introducing an interface for dispatchers, where a server-side implementation dispatches immediately, while the client-side implementation dispatches by running it on main thread of Unity. Due to classes implementating an interface, the Unity types are no longer loaded when creating the packet handler registry instances on the server-side.