### PR TITLE
PredictiveInterpolation bugfix and minor tweaks

### DIFF
--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -1501,8 +1501,7 @@ internal abstract class ServerManager : IServerManager {
     ) {
         var existingPlayer = _playerData.Values.FirstOrDefault(playerData =>
             playerData.Id != netServerClient.Id
-            && (string.Equals(playerData.UniqueClientIdentifier, uniqueIdentifier, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(playerData.AuthKey, clientInfo.AuthKey, StringComparison.OrdinalIgnoreCase)));
+            && string.Equals(playerData.UniqueClientIdentifier, uniqueIdentifier, StringComparison.OrdinalIgnoreCase));
 
         if (existingPlayer is null)
             return;


### PR DESCRIPTION
- Fixed a bug where a user's player container could enable with stale data, resulting in the user momentarily appearing to warp to an arbitrary location in the scene until their actual location is updated.

- Added a small tweak to ManualUpdate to exit out early if _hasNewServerData is false.

- Used the RTT tier defined values when enabling rather than arbitrary numbers.