### PR TITLE
Match session takeover on transport identifier only

### DIFF
--- a/SSMP/Game/Server/ServerManager.cs
+++ b/SSMP/Game/Server/ServerManager.cs
@@ -1501,8 +1501,7 @@ internal abstract class ServerManager : IServerManager {
     ) {
         var existingPlayer = _playerData.Values.FirstOrDefault(playerData =>
             playerData.Id != netServerClient.Id
-            && (string.Equals(playerData.UniqueClientIdentifier, uniqueIdentifier, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(playerData.AuthKey, clientInfo.AuthKey, StringComparison.OrdinalIgnoreCase)));
+            && string.Equals(playerData.UniqueClientIdentifier, uniqueIdentifier, StringComparison.OrdinalIgnoreCase));
 
         if (existingPlayer is null)
             return;


### PR DESCRIPTION
Because AuthKey is shared across all clients launched from the same install, two local clients connecting to the same server caused the second connection to disconnect the first. This makes locally testing dev builds difficult. My mistake from a previous PR.