### PR TITLE
Support large addon chunk payloads and prevent packet truncation

### DIFF
--- a/SSMP/Api/Client/Networking/ClientAddonNetworkReceiver.cs
+++ b/SSMP/Api/Client/Networking/ClientAddonNetworkReceiver.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using SSMP.Api.Networking;
 using SSMP.Collection;
 using SSMP.Networking.Packet;
+using SSMP.Networking.Packet.Connection;
 using SSMP.Networking.Packet.Update;
 
 namespace SSMP.Api.Client.Networking;
@@ -55,10 +57,12 @@ internal class ClientAddonNetworkReceiver {
         }
 
         // Assign the addon packet info in the dictionary of the client update packet
-        ClientUpdatePacket.AddonPacketInfoDict[ClientAddon.Id.Value] = new AddonPacketInfo(
+        var addonPacketInfo = new AddonPacketInfo(
             PacketInstantiator!,
             PacketIdSize
         );
+        ClientUpdatePacket.AddonPacketInfoDict[ClientAddon.Id.Value] = addonPacketInfo;
+        ClientConnectionPacket.AddonPacketInfoDict[ClientAddon.Id.Value] = addonPacketInfo;
 
         foreach (var idHandlerPair in PacketHandlers) {
             PacketManager.RegisterClientAddonUpdatePacketHandler(

--- a/SSMP/Api/Client/Networking/ClientAddonNetworkSender.cs
+++ b/SSMP/Api/Client/Networking/ClientAddonNetworkSender.cs
@@ -1,4 +1,5 @@
 using System;
+using SSMP.Api.Networking;
 using SSMP.Networking.Client;
 using SSMP.Networking.Packet;
 
@@ -61,7 +62,8 @@ internal class ClientAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                InvalidPacketIdMsg);
+                InvalidPacketIdMsg
+            );
         }
 
         if (!_clientAddon.Id.HasValue) {
@@ -87,7 +89,8 @@ internal class ClientAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                InvalidPacketIdMsg);
+                InvalidPacketIdMsg
+            );
         }
 
         if (!_clientAddon.Id.HasValue) {
@@ -100,5 +103,33 @@ internal class ClientAddonNetworkSender<TPacketId> :
             _packetIdSize,
             packetData
         );
+    }
+
+    /// <inheritdoc/>
+    public void SendChunkData(TPacketId packetId, IPacketData packetData) {
+        var (idValue, addonId) = ValidateCommon(packetId);
+        _netClient.UpdateManager.SendChunkPacket(
+            ChunkAddonPacketBuilder.BuildServerBound(idValue, addonId, packetData)
+        );
+    }
+
+    /// <summary>
+    /// Validates the common client-side preconditions required before sending chunk data.
+    /// </summary>
+    /// <param name="packetId">The addon packet identifier to validate and resolve.</param>
+    /// <returns>
+    /// The resolved packet ID byte value and the current addon ID.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the client is not connected, the addon has no assigned ID, or the packet ID is invalid.
+    /// </exception>
+    private (byte idValue, byte addonId) ValidateCommon(TPacketId packetId) {
+        if (!_netClient.IsConnected) {
+            throw new InvalidOperationException(NotConnectedMsg);
+        }
+
+        return !_clientAddon.Id.HasValue
+            ? throw new InvalidOperationException(NoClientAddonId)
+            : (ResolvePacketId(packetId, InvalidPacketIdMsg), _clientAddon.Id.Value);
     }
 }

--- a/SSMP/Api/Client/Networking/IClientAddonNetworkSender.cs
+++ b/SSMP/Api/Client/Networking/IClientAddonNetworkSender.cs
@@ -29,4 +29,12 @@ public interface IClientAddonNetworkSender<in TPacketId> where TPacketId : Enum 
         TPacketId packetId,
         TPacketData packetData
     ) where TPacketData : IPacketData, new();
+
+    /// <summary>
+    /// Send a single instance of IPacketData over the network through the chunk system with the given packet ID.
+    /// This should be used for large packets (exceeding 64 KiB).
+    /// </summary>
+    /// <param name="packetId">The packet ID.</param>
+    /// <param name="packetData">An instance of IPacketData to send.</param>
+    void SendChunkData(TPacketId packetId, IPacketData packetData);
 }

--- a/SSMP/Api/Client/Networking/INetClient.cs
+++ b/SSMP/Api/Client/Networking/INetClient.cs
@@ -6,7 +6,7 @@ namespace SSMP.Api.Client.Networking;
 /// <summary>
 /// The net client for all network-related interaction.
 /// </summary>
-public interface INetClient {
+public interface INetClient : IDisposable {
     /// <summary>
     /// Whether the client is currently connected to a server.
     /// </summary>

--- a/SSMP/Api/Networking/AddonNetworkTransmitter.cs
+++ b/SSMP/Api/Networking/AddonNetworkTransmitter.cs
@@ -1,7 +1,7 @@
 using System;
 using SSMP.Collection;
 
-namespace SSMP.Api.Client.Networking;
+namespace SSMP.Api.Networking;
 
 /// <summary>
 /// Static class for addon network transmitters.
@@ -37,9 +37,19 @@ internal abstract class AddonNetworkTransmitter<TPacketId> where TPacketId : Enu
     /// <summary>
     /// A lookup for packet IDs and corresponding raw byte values.
     /// </summary>
-    protected readonly BiLookup<TPacketId, byte> PacketIdLookup;
+    protected readonly BiLookup<TPacketId, byte> PacketIdLookup =
+        AddonNetworkTransmitter.ConstructPacketIdLookup<TPacketId>();
 
-    protected AddonNetworkTransmitter() {
-        PacketIdLookup = AddonNetworkTransmitter.ConstructPacketIdLookup<TPacketId>();
+    /// <summary>
+    /// Resolve the given addon packet ID to its wire-format byte value.
+    /// </summary>
+    /// <param name="packetId">The enum packet ID to resolve.</param>
+    /// <param name="invalidPacketIdMessage">Exception message used when the packet ID is unknown.</param>
+    /// <returns>The byte value for the packet ID.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the packet ID is not part of the lookup.</exception>
+    protected byte ResolvePacketId(TPacketId packetId, string invalidPacketIdMessage) {
+        return !PacketIdLookup.TryGetValue(packetId, out var idValue)
+            ? throw new InvalidOperationException(invalidPacketIdMessage)
+            : idValue;
     }
 }

--- a/SSMP/Api/Server/Networking/IServerAddonNetworkSender.cs
+++ b/SSMP/Api/Server/Networking/IServerAddonNetworkSender.cs
@@ -78,4 +78,33 @@ public interface IServerAddonNetworkSender<in TPacketId> where TPacketId : Enum 
         TPacketId packetId,
         TPacketData packetData
     ) where TPacketData : IPacketData, new();
+
+    /// <summary>
+    /// Send a single instance of IPacketData with the given packet ID over the network to the player
+    /// with the given ID through the chunk system.
+    /// This should be used for large packets (exceeding 64 KiB).
+    /// </summary>
+    /// <param name="packetId">The packet ID.</param>
+    /// <param name="packetData">An instance of IPacketData to send.</param>
+    /// <param name="playerId">The ID of the player.</param>
+    void SendChunkData(TPacketId packetId, IPacketData packetData, ushort playerId);
+
+    /// <summary>
+    /// Send a single instance of IPacketData with the given packet ID over the network to the players
+    /// with the given IDs through the chunk system.
+    /// This should be used for large packets (exceeding 64 KiB).
+    /// </summary>
+    /// <param name="packetId">The packet ID.</param>
+    /// <param name="packetData">An instance of IPacketData to send.</param>
+    /// <param name="playerIds">The IDs of the players.</param>
+    void SendChunkData(TPacketId packetId, IPacketData packetData, params ushort[] playerIds);
+
+    /// <summary>
+    /// Send a single instance of IPacketData with the given packet ID over the network to all connected
+    /// players through the chunk system.
+    /// This should be used for large packets (exceeding 64 KiB).
+    /// </summary>
+    /// <param name="packetId">The packet ID.</param>
+    /// <param name="packetData">An instance of IPacketData to send.</param>
+    void BroadcastChunkData(TPacketId packetId, IPacketData packetData);
 }

--- a/SSMP/Api/Server/Networking/ServerAddonNetworkReceiver.cs
+++ b/SSMP/Api/Server/Networking/ServerAddonNetworkReceiver.cs
@@ -1,5 +1,5 @@
 using System;
-using SSMP.Api.Client.Networking;
+using SSMP.Api.Networking;
 using SSMP.Networking.Packet;
 
 namespace SSMP.Api.Server.Networking;
@@ -42,10 +42,7 @@ internal class ServerAddonNetworkReceiver<TPacketId> :
 
     /// <inheritdoc/>
     public void RegisterPacketHandler(TPacketId packetId, Action<ushort> handler) {
-        if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
-            throw new InvalidOperationException(
-                InvalidPacketIdMsg);
-        }
+        var idValue = ResolvePacketId(packetId, InvalidPacketIdMsg);
 
         if (!_serverAddon.Id.HasValue) {
             throw new InvalidOperationException(NoAddonIdMsg);
@@ -61,10 +58,7 @@ internal class ServerAddonNetworkReceiver<TPacketId> :
     /// <inheritdoc/>
     public void RegisterPacketHandler<TPacketData>(TPacketId packetId,
         GenericServerPacketHandler<TPacketData> handler) where TPacketData : IPacketData {
-        if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
-            throw new InvalidOperationException(
-                InvalidPacketIdMsg);
-        }
+        var idValue = ResolvePacketId(packetId, InvalidPacketIdMsg);
 
         if (!_serverAddon.Id.HasValue) {
             throw new InvalidOperationException(NoAddonIdMsg);
@@ -79,10 +73,10 @@ internal class ServerAddonNetworkReceiver<TPacketId> :
 
     /// <inheritdoc/>
     public void DeregisterPacketHandler(TPacketId packetId) {
-        if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
-            throw new InvalidOperationException(
-                "Given packet ID was not part of enum when creating this network receiver");
-        }
+        var idValue = ResolvePacketId(
+            packetId,
+            "Given packet ID was not part of enum when creating this network receiver"
+        );
 
         if (!_serverAddon.Id.HasValue) {
             throw new InvalidOperationException(NoAddonIdMsg);

--- a/SSMP/Api/Server/Networking/ServerAddonNetworkSender.cs
+++ b/SSMP/Api/Server/Networking/ServerAddonNetworkSender.cs
@@ -1,5 +1,5 @@
 using System;
-using SSMP.Api.Client.Networking;
+using SSMP.Api.Networking;
 using SSMP.Networking.Packet;
 using SSMP.Networking.Server;
 
@@ -62,7 +62,8 @@ internal class ServerAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                PacketIdInvalidExceptionMsg);
+                PacketIdInvalidExceptionMsg
+            );
         }
 
         var updateManager = _netServer.GetUpdateManagerForClient(playerId);
@@ -97,7 +98,8 @@ internal class ServerAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                PacketIdInvalidExceptionMsg);
+                PacketIdInvalidExceptionMsg
+            );
         }
 
         if (!_serverAddon.Id.HasValue) {
@@ -105,13 +107,14 @@ internal class ServerAddonNetworkSender<TPacketId> :
         }
 
         _netServer.SetDataForAllClients(updateManager => {
-            updateManager?.SetAddonData(
-                _serverAddon.Id.Value,
-                idValue,
-                _packetIdSize,
-                packetData
-            );
-        });
+                updateManager?.SetAddonData(
+                    _serverAddon.Id.Value,
+                    idValue,
+                    _packetIdSize,
+                    packetData
+                );
+            }
+        );
     }
 
     /// <inheritdoc/>
@@ -126,7 +129,8 @@ internal class ServerAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                PacketIdInvalidExceptionMsg);
+                PacketIdInvalidExceptionMsg
+            );
         }
 
         var updateManager = _netServer.GetUpdateManagerForClient(playerId);
@@ -168,7 +172,8 @@ internal class ServerAddonNetworkSender<TPacketId> :
 
         if (!PacketIdLookup.TryGetValue(packetId, out var idValue)) {
             throw new InvalidOperationException(
-                PacketIdInvalidExceptionMsg);
+                PacketIdInvalidExceptionMsg
+            );
         }
 
         if (!_serverAddon.Id.HasValue) {
@@ -176,12 +181,69 @@ internal class ServerAddonNetworkSender<TPacketId> :
         }
 
         _netServer.SetDataForAllClients(updateManager => {
-            updateManager?.SetAddonDataAsCollection(
-                _serverAddon.Id.Value,
-                idValue,
-                _packetIdSize,
-                packetData
-            );
-        });
+                updateManager?.SetAddonDataAsCollection(
+                    _serverAddon.Id.Value,
+                    idValue,
+                    _packetIdSize,
+                    packetData
+                );
+            }
+        );
+    }
+
+    /// <inheritdoc/>
+    public void SendChunkData(TPacketId packetId, IPacketData packetData, ushort playerId) {
+        var (idValue, addonId) = ValidateCommon(packetId);
+
+        var updateManager = _netServer.GetUpdateManagerForClient(playerId);
+        if (updateManager == null) {
+            throw new InvalidOperationException($"Player with ID '{playerId}' is not connected");
+        }
+
+        updateManager.SendChunkPacket(
+            ChunkAddonPacketBuilder.BuildClientBound(idValue, addonId, packetData)
+        );
+    }
+
+    /// <inheritdoc/>
+    public void SendChunkData(TPacketId packetId, IPacketData packetData, params ushort[] playerIds) {
+        var (idValue, addonId) = ValidateCommon(packetId);
+        var packet = ChunkAddonPacketBuilder.BuildClientBound(idValue, addonId, packetData);
+
+        foreach (var playerId in playerIds) {
+            var updateManager = _netServer.GetUpdateManagerForClient(playerId);
+            if (updateManager == null) {
+                throw new InvalidOperationException($"Player with ID '{playerId}' is not connected");
+            }
+
+            updateManager.SendChunkPacket(packet);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void BroadcastChunkData(TPacketId packetId, IPacketData packetData) {
+        var (idValue, addonId) = ValidateCommon(packetId);
+        var packet = ChunkAddonPacketBuilder.BuildClientBound(idValue, addonId, packetData);
+        _netServer.SetDataForAllClients(updateManager => updateManager?.SendChunkPacket(packet));
+    }
+
+    /// <summary>
+    /// Validates the common server-side preconditions required before sending chunk data.
+    /// </summary>
+    /// <param name="packetId">The addon packet identifier to validate and resolve.</param>
+    /// <returns>
+    /// The resolved packet ID byte value and the current addon ID.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the server is not started, the addon has no assigned ID, or the packet ID is invalid.
+    /// </exception>
+    private (byte idValue, byte addonId) ValidateCommon(TPacketId packetId) {
+        if (!_netServer.IsStarted) {
+            throw new InvalidOperationException(ServerNotStartedExceptionMsg);
+        }
+
+        return !_serverAddon.Id.HasValue
+            ? throw new InvalidOperationException(NoAddonIdMsg)
+            : (ResolvePacketId(packetId, PacketIdInvalidExceptionMsg), _serverAddon.Id.Value);
     }
 }

--- a/SSMP/Networking/Chunk/ChunkReceiver.cs
+++ b/SSMP/Networking/Chunk/ChunkReceiver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using SSMP.Logging;
 using SSMP.Networking.Packet.Data;
 
 namespace SSMP.Networking.Chunk;
@@ -126,24 +127,24 @@ internal sealed class ChunkReceiver {
 
             // Validate slice count and ID bounds
             if (sliceData.NumSlices is < 1 or > ConnectionManager.MaxSlicesPerChunk) {
-                Logging.Logger.Error($"Invalid slice count received: {sliceData.NumSlices}");
+                Logger.Error($"Invalid slice count received: {sliceData.NumSlices}");
                 return;
             }
 
             if (sliceData.SliceId >= sliceData.NumSlices) {
-                Logging.Logger.Error($"Invalid SliceId {sliceData.SliceId} for NumSlices {sliceData.NumSlices}");
+                Logger.Error($"Invalid SliceId {sliceData.SliceId} for NumSlices {sliceData.NumSlices}");
                 return;
             }
 
             if (sliceData.Data.Length > ConnectionManager.MaxSliceSize) {
-                Logging.Logger.Error($"Invalid slice data length: {sliceData.Data.Length}");
+                Logger.Error($"Invalid slice data length: {sliceData.Data.Length}");
                 return;
             }
 
             var maxAllowedSlices = (MaxAllowedChunkSize + ConnectionManager.MaxSliceSize - 1) /
                                    ConnectionManager.MaxSliceSize;
             if (sliceData.NumSlices > maxAllowedSlices) {
-                Logging.Logger.Error(
+                Logger.Error(
                     $"Rejected chunk with {sliceData.NumSlices} slices because it exceeds the allowed limit of {maxAllowedSlices}."
                 );
                 return;
@@ -175,8 +176,7 @@ internal sealed class ChunkReceiver {
                 }
                 default: {
                     // If the received number of slices does not match the number slices we are keeping track of, we
-                    // discard
-                    // the slice altogether as it is likely not correct
+                    // discard the slice altogether as it is likely not correct
                     if (_numSlices != sliceData.NumSlices) {
                         //Logger.Debug("Number of slices in slice packet does not correspond with local number of
                         // slices");
@@ -209,7 +209,7 @@ internal sealed class ChunkReceiver {
                 if (sliceData.SliceId == _numSlices - 1) {
                     _chunkSize = (_numSlices - 1) * ConnectionManager.MaxSliceSize + sliceData.Data.Length;
                     if (_chunkSize > MaxAllowedChunkSize) {
-                        Logging.Logger.Error($"Rejected chunk larger than allowed max size: {_chunkSize}");
+                        Logger.Error($"Rejected chunk larger than allowed max size: {_chunkSize}");
                         SoftReset();
                         _isReceiving = false;
                         _chunkId = null;

--- a/SSMP/Networking/Chunk/ChunkReceiver.cs
+++ b/SSMP/Networking/Chunk/ChunkReceiver.cs
@@ -97,6 +97,7 @@ internal sealed class ChunkReceiver {
         _setSliceAckData = setSliceAckData ?? throw new ArgumentNullException(nameof(setSliceAckData));
     }
 
+
     /// <summary>
     /// Process received slice data by checking whether we have not yet received this slice and adding it to the data
     /// array and marking it received. If this is the first slice received in this chunk we note that we are
@@ -105,136 +106,44 @@ internal sealed class ChunkReceiver {
     /// </summary>
     /// <param name="sliceData">The received slice data.</param>
     public void ProcessReceivedData(SliceData sliceData) {
-        var shouldSendAck = false;
-        var shouldTriggerEvent = false;
-        var isStaleDuplicate = false;
-        Packet.Packet? packetToTrigger = null;
+        Packet.Packet? completedPacket = null;
+        bool shouldSendAck;
 
         lock (_stateLock) {
-            //Logger.Debug($"Received slice packet: {sliceData.ChunkId}, {sliceData.SliceId}, {sliceData.NumSlices}");
+            ResetIfTimedOut();
 
-            if (_isReceiving && IsTimedOut()) {
-                SoftReset();
-                _isReceiving = false;
-                _chunkId = null;
-            }
-
-            // We check if the received chunk ID is smaller than the current chunk ID accounting for wrapping IDs
-            if (_chunkId.HasValue && ConnectionManager.IsWrappingIdSmaller(sliceData.ChunkId, _chunkId.Value)) {
-                //Logger.Debug("Chunk ID of received slice packet is smaller than currently receiving chunk");
+            if (IsStaleChunkId(sliceData)) {
                 return;
             }
 
-            // Validate slice count and ID bounds
-            if (sliceData.NumSlices is < 1 or > ConnectionManager.MaxSlicesPerChunk) {
-                Logger.Error($"Invalid slice count received: {sliceData.NumSlices}");
+            if (!IsSliceDataValid(sliceData)) {
                 return;
             }
 
-            if (sliceData.SliceId >= sliceData.NumSlices) {
-                Logger.Error($"Invalid SliceId {sliceData.SliceId} for NumSlices {sliceData.NumSlices}");
-                return;
-            }
-
-            if (sliceData.Data.Length > ConnectionManager.MaxSliceSize) {
-                Logger.Error($"Invalid slice data length: {sliceData.Data.Length}");
-                return;
-            }
-
-            var maxAllowedSlices = (MaxAllowedChunkSize + ConnectionManager.MaxSliceSize - 1) /
-                                   ConnectionManager.MaxSliceSize;
-            if (sliceData.NumSlices > maxAllowedSlices) {
-                Logger.Error(
-                    $"Rejected chunk with {sliceData.NumSlices} slices because it exceeds the allowed limit of {maxAllowedSlices}."
-                );
-                return;
-            }
-
-            switch (_isReceiving) {
-                // Ignore slices from newer chunks while the current chunk is still incomplete.
-                case true when _chunkId.HasValue && sliceData.ChunkId != _chunkId.Value:
+            switch (ResolveChunkState(sliceData)) {
+                case ChunkResolution.Ignore:
                     return;
-                case false when !_chunkId.HasValue || sliceData.ChunkId != _chunkId.Value:
-                    //Logger.Debug($"Received new chunk with ID: {sliceData.ChunkId}");
-                    SoftReset();
 
-                    _chunkId = sliceData.ChunkId;
-                    _isReceiving = true;
-                    _numSlices = sliceData.NumSlices;
-                    _received = new bool[_numSlices];
-                    _sliceSegments = new byte[_numSlices][];
-                    _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+                case ChunkResolution.DuplicateOfCompleted:
+                    shouldSendAck = true;
                     break;
-                case false: {
-                    if (sliceData.ChunkId == _chunkId.Value) {
-                        //Logger.Debug("Already received all slices, resending ack packet");
-                        shouldSendAck = true;
-                        isStaleDuplicate = true;
-                    }
 
-                    break;
-                }
-                default: {
-                    // If the received number of slices does not match the number slices we are keeping track of, we
-                    // discard the slice altogether as it is likely not correct
-                    if (_numSlices != sliceData.NumSlices) {
-                        //Logger.Debug("Number of slices in slice packet does not correspond with local number of
-                        // slices");
+                case ChunkResolution.Accept:
+                    if (!StoreSlice(sliceData, out var isChunkComplete)) {
+                        // Duplicate within the current chunk, out-of-bounds SliceId, or rejected as oversized.
+                        // No ack in any of these cases - matches original behavior.
                         return;
                     }
 
+                    shouldSendAck = true;
+
+                    if (isChunkComplete) {
+                        completedPacket = AssembleAndResetChunk();
+                    }
+
                     break;
-                }
-            }
-
-            if (!isStaleDuplicate) {
-                if (_received == null || _sliceSegments == null) return;
-                if (sliceData.SliceId >= _received.Length) return;
-
-                if (_received[sliceData.SliceId]) {
-                    //Logger.Debug($"Received duplicate slice: {sliceData.SliceId}, ignoring");
-                    return;
-                }
-
-                _numReceivedSlices += 1;
-                _received[sliceData.SliceId] = true;
-                _lastReceiveTimestamp = Stopwatch.GetTimestamp();
-
-                // Store a reference to the received slice data segment directly to avoid GC LOH allocation pressure
-                _sliceSegments[sliceData.SliceId] = sliceData.Data;
-
-                // Whenever the last-ID slice arrives, correct the chunk size to account for its (potentially partial)
-                // length.
-                // This must happen before the assembly check below so that out-of-order delivery is handled correctly.
-                if (sliceData.SliceId == _numSlices - 1) {
-                    _chunkSize = (_numSlices - 1) * ConnectionManager.MaxSliceSize + sliceData.Data.Length;
-                    if (_chunkSize > MaxAllowedChunkSize) {
-                        Logger.Error($"Rejected chunk larger than allowed max size: {_chunkSize}");
-                        SoftReset();
-                        _isReceiving = false;
-                        _chunkId = null;
-                        return;
-                    }
-                    //Logger.Debug($"Corrected chunk size after receiving last-ID slice: {_chunkSize}");
-                }
-
-                shouldSendAck = true;
-
-                if (_numReceivedSlices == _numSlices) {
-                    var byteArray = new byte[_chunkSize];
-                    var offset = 0;
-                    for (var i = 0; i < _numSlices; i++) {
-                        var segment = _sliceSegments[i];
-                        Array.Copy(segment, 0, byteArray, offset, segment.Length);
-                        offset += segment.Length;
-                    }
-
-                    packetToTrigger = new Packet.Packet(byteArray);
-
-                    _sliceSegments = null;
-                    shouldTriggerEvent = true;
-                    _isReceiving = false;
-                }
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 
@@ -243,9 +152,174 @@ internal sealed class ChunkReceiver {
             SendAckData();
         }
 
-        if (shouldTriggerEvent && packetToTrigger != null) {
-            ChunkReceivedEvent?.Invoke(packetToTrigger);
+        if (completedPacket != null) {
+            ChunkReceivedEvent?.Invoke(completedPacket);
         }
+    }
+
+    /// <summary>
+    /// Resets receiving state if the in-progress chunk has gone too long without a new slice. No-op if we are
+    /// not currently receiving a chunk. Must be called while holding <see cref="_stateLock"/>.
+    /// </summary>
+    private void ResetIfTimedOut() {
+        if (_isReceiving && IsTimedOut()) {
+            SoftReset();
+            _isReceiving = false;
+            _chunkId = null;
+        }
+    }
+
+    /// <summary>
+    /// Checks whether the slice's chunk ID is older than the chunk we're currently tracking, accounting for ID
+    /// wraparound. Stale slices are dropped silently (no ack), since acking them could confuse the sender about
+    /// which chunk we're actually on.
+    /// </summary>
+    private bool IsStaleChunkId(SliceData sliceData) {
+        return _chunkId.HasValue && ConnectionManager.IsWrappingIdSmaller(sliceData.ChunkId, _chunkId.Value);
+    }
+
+    /// <summary>
+    /// Validates structural bounds on incoming slice data before any state mutation happens. Rejects malformed
+    /// slices and slice counts large enough to indicate an oversized-chunk attempt.
+    /// </summary>
+    private bool IsSliceDataValid(SliceData sliceData) {
+        if (sliceData.NumSlices is < 1 or > ConnectionManager.MaxSlicesPerChunk) {
+            Logger.Error($"Invalid slice count received: {sliceData.NumSlices}");
+            return false;
+        }
+
+        if (sliceData.SliceId >= sliceData.NumSlices) {
+            Logger.Error($"Invalid SliceId {sliceData.SliceId} for NumSlices {sliceData.NumSlices}");
+            return false;
+        }
+
+        if (sliceData.Data.Length > ConnectionManager.MaxSliceSize) {
+            Logger.Error($"Invalid slice data length: {sliceData.Data.Length}");
+            return false;
+        }
+
+        var maxAllowedSlices = (MaxAllowedChunkSize + ConnectionManager.MaxSliceSize - 1) /
+                               ConnectionManager.MaxSliceSize;
+        if (sliceData.NumSlices > maxAllowedSlices) {
+            Logger.Error(
+                $"Rejected chunk with {sliceData.NumSlices} slices because it exceeds the allowed limit of {maxAllowedSlices}."
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines how the slice relates to our current receiving state, and mutates that state if the slice
+    /// starts a brand-new chunk. Must be called while holding <see cref="_stateLock"/>.
+    /// </summary>
+    private ChunkResolution ResolveChunkState(SliceData sliceData) {
+        switch (_isReceiving) {
+            // Ignore slices from newer chunks while the current chunk is still incomplete.
+            case true when _chunkId.HasValue && sliceData.ChunkId != _chunkId.Value:
+                return ChunkResolution.Ignore;
+
+            case false when !_chunkId.HasValue || sliceData.ChunkId != _chunkId.Value:
+                BeginNewChunk(sliceData);
+                return ChunkResolution.Accept;
+
+            case false:
+                // _isReceiving is false and the chunk ID matches: we already fully received this chunk and the
+                // sender is re-sending because our ack was lost. Re-ack without reprocessing.
+                return ChunkResolution.DuplicateOfCompleted;
+
+            default:
+                // _isReceiving is true here, and within this class _chunkId is always set alongside _isReceiving
+                // (see BeginNewChunk), so the chunk ID is guaranteed to match. We still rely on _numSlices to
+                // catch a malformed/mismatched resend rather than trusting the match blindly.
+                return _numSlices != sliceData.NumSlices ? ChunkResolution.Ignore : ChunkResolution.Accept;
+        }
+    }
+
+    /// <summary>
+    /// Resets local receiving state and begins tracking a new chunk identified by <paramref name="sliceData"/>.
+    /// </summary>
+    private void BeginNewChunk(SliceData sliceData) {
+        SoftReset();
+
+        _chunkId = sliceData.ChunkId;
+        _isReceiving = true;
+        _numSlices = sliceData.NumSlices;
+        _received = new bool[_numSlices];
+        _sliceSegments = new byte[_numSlices][];
+        _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    /// <summary>
+    /// Stores a slice belonging to the chunk currently being received, correcting the tracked chunk size once
+    /// the last-indexed slice arrives. Must be called while holding <see cref="_stateLock"/>, and only when
+    /// <see cref="ResolveChunkState"/> returned <see cref="ChunkResolution.Accept"/>.
+    /// </summary>
+    /// <param name="sliceData">The slice to store.</param>
+    /// <param name="isChunkComplete">True if this was the final slice needed to complete the chunk.</param>
+    /// <returns>
+    /// False if the slice was a duplicate, out of bounds, or the corrected chunk size exceeded the allowed
+    /// maximum (receiving state has already been reset in that case). True otherwise.
+    /// </returns>
+    private bool StoreSlice(SliceData sliceData, out bool isChunkComplete) {
+        isChunkComplete = false;
+
+        if (_received == null || _sliceSegments == null) {
+            return false;
+        }
+
+        if (sliceData.SliceId >= _received.Length) {
+            return false;
+        }
+
+        if (_received[sliceData.SliceId]) {
+            // Duplicate slice within the current chunk; ignore.
+            return false;
+        }
+
+        _numReceivedSlices += 1;
+        _received[sliceData.SliceId] = true;
+        _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+
+        // Store a reference to the received slice data segment directly to avoid GC LOH allocation pressure
+        _sliceSegments[sliceData.SliceId] = sliceData.Data;
+
+        // Whenever the last-ID slice arrives, correct the chunk size to account for its (potentially partial)
+        // length. This must happen before the completion check below so out-of-order delivery is handled correctly.
+        if (sliceData.SliceId == _numSlices - 1) {
+            _chunkSize = (_numSlices - 1) * ConnectionManager.MaxSliceSize + sliceData.Data.Length;
+            if (_chunkSize > MaxAllowedChunkSize) {
+                Logger.Error($"Rejected chunk larger than allowed max size: {_chunkSize}");
+                SoftReset();
+                _isReceiving = false;
+                _chunkId = null;
+                return false;
+            }
+        }
+
+        isChunkComplete = _numReceivedSlices == _numSlices;
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the final packet from all received slice segments once a chunk is fully assembled, and releases
+    /// the per-slice buffer now that it's no longer needed. Must only be called once <see cref="StoreSlice"/>
+    /// has reported the chunk complete.
+    /// </summary>
+    private Packet.Packet AssembleAndResetChunk() {
+        var byteArray = new byte[_chunkSize];
+        var offset = 0;
+        for (var i = 0; i < _numSlices; i++) {
+            var segment = _sliceSegments![i];
+            Array.Copy(segment, 0, byteArray, offset, segment.Length);
+            offset += segment.Length;
+        }
+
+        _sliceSegments = null;
+        _isReceiving = false;
+
+        return new Packet.Packet(byteArray);
     }
 
     /// <summary>
@@ -310,4 +384,18 @@ internal sealed class ChunkReceiver {
         var elapsedMillis = (Stopwatch.GetTimestamp() - _lastReceiveTimestamp) * 1000 / Stopwatch.Frequency;
         return elapsedMillis > ReceiveTimeoutMillis;
     }
+}
+
+/// <summary>
+/// Describes how an incoming slice relates to the chunk currently being tracked.
+/// </summary>
+internal enum ChunkResolution {
+    /// <summary>Slice belongs to a chunk newer than the one we're currently receiving; drop it for now.</summary>
+    Ignore,
+
+    /// <summary>Slice belongs to a chunk we already fully received; our prior ack was likely lost.</summary>
+    DuplicateOfCompleted,
+
+    /// <summary>Slice belongs to the chunk we are currently receiving (just started, or already in progress).</summary>
+    Accept
 }

--- a/SSMP/Networking/Chunk/ChunkReceiver.cs
+++ b/SSMP/Networking/Chunk/ChunkReceiver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using SSMP.Networking.Packet.Data;
 
 namespace SSMP.Networking.Chunk;
@@ -17,37 +18,65 @@ internal delegate void SetSliceAckDataDelegate(byte chunkId, ushort numSlices, b
 /// </summary>
 internal sealed class ChunkReceiver {
     /// <summary>
-    /// Boolean array where each value indicates whether the slice of the same index was received.
+    /// The number of milliseconds after which an incomplete chunk is considered stale and reset.
     /// </summary>
-    private readonly bool[] _received;
+    private const int ReceiveTimeoutMillis = 5000;
+
     /// <summary>
-    /// Byte array that contains (parts of) the chunk data that is received.
+    /// Lock object for synchronizing access to shared receiver state.
     /// </summary>
-    private readonly byte[] _chunkData;
+    private readonly object _stateLock = new();
+
+    /// <summary>
+    /// Boolean array where each value indicates whether the slice of the same index was received.
+    /// Allocated dynamically for the current chunk.
+    /// </summary>
+    private bool[]? _received;
+
+    /// <summary>
+    /// Array of byte array segments representing the received slices of the current chunk.
+    /// Allocated dynamically for the current chunk.
+    /// </summary>
+    private byte[][]? _sliceSegments;
 
     /// <summary>
     /// Whether we are currently receiving a chunk. If not, receiving a slice containing a chunk ID that is one higher
     /// that the last received chunk will start the reception process again.
     /// </summary>
     private bool _isReceiving;
+
     /// <summary>
     /// The currently (if receiving) or last received (when not receiving) chunk ID.
+    /// Null if no chunk has been received yet.
     /// </summary>
-    private byte _chunkId = 255;
+    private byte? _chunkId;
+
     /// <summary>
     /// The size of the chunk that we are currently receiving. Only calculated when the last slice is received, since
     /// that is the only slice with a different slice size.
     /// </summary>
     private int _chunkSize;
+
     /// <summary>
     /// The number of slices that the chunk we are currently receiving contains. Set whenever we receive the first
     /// slice in a chunk.
     /// </summary>
     private int _numSlices;
+
     /// <summary>
     /// The number of slices we have received so far. Used to keep track when all slices are received.
     /// </summary>
     private int _numReceivedSlices;
+
+    /// <summary>
+    /// Timestamp of when the last slice for the current chunk was received.
+    /// </summary>
+    private long _lastReceiveTimestamp;
+
+    /// <summary>
+    /// The maximum chunk size currently accepted by this receiver.
+    /// </summary>
+    public int MaxAllowedChunkSize { get; set; } = ConnectionManager.MaxChunkSize;
 
     /// <summary>
     /// Event that is called when the entirety of a chunk is received.
@@ -65,9 +94,6 @@ internal sealed class ChunkReceiver {
     /// <param name="setSliceAckData">Delegate to call when sending acknowledgement data.</param>
     public ChunkReceiver(SetSliceAckDataDelegate setSliceAckData) {
         _setSliceAckData = setSliceAckData ?? throw new ArgumentNullException(nameof(setSliceAckData));
-        
-        _received = new bool[ConnectionManager.MaxSlicesPerChunk];
-        _chunkData = new byte[ConnectionManager.MaxChunkSize];
     }
 
     /// <summary>
@@ -78,78 +104,139 @@ internal sealed class ChunkReceiver {
     /// </summary>
     /// <param name="sliceData">The received slice data.</param>
     public void ProcessReceivedData(SliceData sliceData) {
-        //Logger.Debug($"Received slice packet: {sliceData.ChunkId}, {sliceData.SliceId}, {sliceData.NumSlices}");
+        bool shouldSendAck = false;
+        bool shouldTriggerEvent = false;
+        bool isStaleDuplicate = false;
+        Packet.Packet? packetToTrigger = null;
 
-        // We check if the received chunk ID is smaller than the current chunk ID accounting for wrapping IDs
-        if (ConnectionManager.IsWrappingIdSmaller(sliceData.ChunkId, _chunkId)) {
-            //Logger.Debug("Chunk ID of received slice packet is smaller than currently receiving chunk");
-            return;
-        }
+        lock (_stateLock) {
+            //Logger.Debug($"Received slice packet: {sliceData.ChunkId}, {sliceData.SliceId}, {sliceData.NumSlices}");
 
-        if (!_isReceiving) {
-            if (sliceData.ChunkId == (byte) (_chunkId + 1)) {
-                //Logger.Debug($"Received new chunk with ID: {sliceData.ChunkId}");
+            if (_isReceiving && IsTimedOut()) {
                 SoftReset();
-                
-                _chunkId += 1;
-                _isReceiving = true;
-                _numSlices = sliceData.NumSlices;
-            } else if (sliceData.ChunkId == _chunkId) {
-                //Logger.Debug("Already received all slices, resending ack packet");
-                SendAckData();
+                _isReceiving = false;
+                _chunkId = null;
+            }
+
+            // We check if the received chunk ID is smaller than the current chunk ID accounting for wrapping IDs
+            if (_chunkId.HasValue && ConnectionManager.IsWrappingIdSmaller(sliceData.ChunkId, _chunkId.Value)) {
+                //Logger.Debug("Chunk ID of received slice packet is smaller than currently receiving chunk");
                 return;
+            }
+
+            // Validate slice count and ID bounds
+            if (sliceData.NumSlices is < 1 or > ConnectionManager.MaxSlicesPerChunk) {
+                Logging.Logger.Error($"Invalid slice count received: {sliceData.NumSlices}");
+                return;
+            }
+
+            if (sliceData.SliceId >= sliceData.NumSlices) {
+                Logging.Logger.Error($"Invalid SliceId {sliceData.SliceId} for NumSlices {sliceData.NumSlices}");
+                return;
+            }
+
+            if (sliceData.Data.Length > ConnectionManager.MaxSliceSize) {
+                Logging.Logger.Error($"Invalid slice data length: {sliceData.Data.Length}");
+                return;
+            }
+
+            var maxAllowedSlices = (MaxAllowedChunkSize + ConnectionManager.MaxSliceSize - 1) /
+                                   ConnectionManager.MaxSliceSize;
+            if (sliceData.NumSlices > maxAllowedSlices) {
+                Logging.Logger.Error(
+                    $"Rejected chunk with {sliceData.NumSlices} slices because it exceeds the allowed limit of {maxAllowedSlices}."
+                );
+                return;
+            }
+
+            // Ignore slices from newer chunks while the current chunk is still incomplete.
+            if (_isReceiving && _chunkId.HasValue && sliceData.ChunkId != _chunkId.Value) {
+                return;
+            }
+
+            if (!_isReceiving) {
+                if (!_chunkId.HasValue || sliceData.ChunkId != _chunkId.Value) {
+                    //Logger.Debug($"Received new chunk with ID: {sliceData.ChunkId}");
+                    SoftReset();
+
+                    _chunkId = sliceData.ChunkId;
+                    _isReceiving = true;
+                    _numSlices = sliceData.NumSlices;
+                    _received = new bool[_numSlices];
+                    _sliceSegments = new byte[_numSlices][];
+                    _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+                } else if (sliceData.ChunkId == _chunkId.Value) {
+                    //Logger.Debug("Already received all slices, resending ack packet");
+                    shouldSendAck = true;
+                    isStaleDuplicate = true;
+                }
             } else {
-                //Logger.Debug($"Received old chunk: {_chunkId}, ignoring");
-                return;
+                // If the received number of slices does not match the number slices we are keeping track of, we discard
+                // the slice altogether as it is likely not correct
+                if (_numSlices != sliceData.NumSlices) {
+                    //Logger.Debug("Number of slices in slice packet does not correspond with local number of slices");
+                    return;
+                }
             }
-        } else {
-            // If the received number of slices does not match the number slices we are keeping track of, we discard
-            // the slice altogether as it is likely not correct
-            if (_numSlices != sliceData.NumSlices) {
-                //Logger.Debug("Number of slices in slice packet does not correspond with local number of slices");
-                return;
+
+            if (!isStaleDuplicate) {
+                if (_received == null || _sliceSegments == null) return;
+                if (sliceData.SliceId >= _received.Length) return;
+
+                if (_received[sliceData.SliceId]) {
+                    //Logger.Debug($"Received duplicate slice: {sliceData.SliceId}, ignoring");
+                    return;
+                }
+
+                _numReceivedSlices += 1;
+                _received[sliceData.SliceId] = true;
+                _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+
+                // Store a reference to the received slice data segment directly to avoid GC LOH allocation pressure
+                _sliceSegments[sliceData.SliceId] = sliceData.Data;
+
+                // Whenever the last-ID slice arrives, correct the chunk size to account for its (potentially partial)
+                // length.
+                // This must happen before the assembly check below so that out-of-order delivery is handled correctly.
+                if (sliceData.SliceId == _numSlices - 1) {
+                    _chunkSize = (_numSlices - 1) * ConnectionManager.MaxSliceSize + sliceData.Data.Length;
+                    if (_chunkSize > MaxAllowedChunkSize) {
+                        Logging.Logger.Error($"Rejected chunk larger than allowed max size: {_chunkSize}");
+                        SoftReset();
+                        _isReceiving = false;
+                        _chunkId = null;
+                        return;
+                    }
+                    //Logger.Debug($"Corrected chunk size after receiving last-ID slice: {_chunkSize}");
+                }
+
+                shouldSendAck = true;
+
+                if (_numReceivedSlices == _numSlices) {
+                    var byteArray = new byte[_chunkSize];
+                    var offset = 0;
+                    for (var i = 0; i < _numSlices; i++) {
+                        var segment = _sliceSegments[i];
+                        Array.Copy(segment, 0, byteArray, offset, segment.Length);
+                        offset += segment.Length;
+                    }
+
+                    packetToTrigger = new Packet.Packet(byteArray);
+
+                    _sliceSegments = null;
+                    shouldTriggerEvent = true;
+                    _isReceiving = false;
+                }
             }
         }
 
-        if (_received[sliceData.SliceId]) {
-            //Logger.Debug($"Received duplicate slice: {sliceData.SliceId}, ignoring");
-            return;
+        // Perform delegate invocation and event triggering outside the state lock to prevent deadlocks
+        if (shouldSendAck) {
+            SendAckData();
         }
 
-        _numReceivedSlices += 1;
-        _received[sliceData.SliceId] = true;
-
-        // Copy over the data from the received slice into the chunk data array at the correct position
-        Array.Copy(
-            sliceData.Data, 
-            0, 
-            _chunkData, 
-            sliceData.SliceId * ConnectionManager.MaxSliceSize, 
-            sliceData.Data.Length
-        );
-        
-        SendAckData();
-
-        // If this is the last slice in the chunk, we can calculate the chunk size
-        if (sliceData.SliceId == _numSlices - 1) {
-            _chunkSize = (_numSlices - 1) * ConnectionManager.MaxSliceSize + sliceData.Data.Length;
-            //Logger.Debug($"Received last slice in chunk, chunk size: {_chunkSize}");
-        }
-
-        if (_numReceivedSlices == _numSlices) {
-            var byteArray = new byte[_chunkSize];
-            Array.Copy(
-                _chunkData,
-                0,
-                byteArray,
-                0,
-                _chunkSize
-            );
-            var packet = new Packet.Packet(byteArray);
-            
-            ChunkReceivedEvent?.Invoke(packet);
-
-            _isReceiving = false;
+        if (shouldTriggerEvent && packetToTrigger != null) {
+            ChunkReceivedEvent?.Invoke(packetToTrigger);
         }
     }
 
@@ -158,20 +245,36 @@ internal sealed class ChunkReceiver {
     /// default values.
     /// </summary>
     public void Reset() {
-        SoftReset();
-        
-        _isReceiving = false;
-        _chunkId = 255;
+        lock (_stateLock) {
+            SoftReset();
+
+            _isReceiving = false;
+            _chunkId = null;
+        }
     }
 
     /// <summary>
     /// Send acknowledgement data containing the boolean array of all slices that have been acknowledged thus far.
     /// </summary>
     private void SendAckData() {
-        var acked = new bool[_numSlices];
-        Array.Copy(_received, acked, _numSlices);
+        bool shouldSendAck = false;
+        byte ackChunkId = 0;
+        ushort ackNumSlices = 0;
+        bool[]? ackedSlices = null;
 
-        SetSliceAckData(_chunkId, (ushort) _numSlices, acked);
+        lock (_stateLock) {
+            if (_received != null && _chunkId.HasValue) {
+                shouldSendAck = true;
+                ackChunkId = _chunkId.Value;
+                ackNumSlices = (ushort) _numSlices;
+                ackedSlices = new bool[_numSlices];
+                Array.Copy(_received, ackedSlices, _numSlices);
+            }
+        }
+
+        if (shouldSendAck && ackedSlices != null) {
+            _setSliceAckData(ackChunkId, ackNumSlices, ackedSlices);
+        }
     }
 
     /// <summary>
@@ -179,20 +282,24 @@ internal sealed class ChunkReceiver {
     /// slices, and number of received slices to 0.
     /// </summary>
     private void SoftReset() {
-        Array.Clear(_received, 0, _received.Length);
+        _received = null;
+        _sliceSegments = null;
 
         _chunkSize = 0;
         _numSlices = 0;
         _numReceivedSlices = 0;
+        _lastReceiveTimestamp = 0;
     }
 
     /// <summary>
-    /// Set the slice ack data using the injected delegate.
+    /// Checks whether the active partial chunk has timed out.
     /// </summary>
-    /// <param name="chunkId">The ID of the chunk for this acknowledgement.</param>
-    /// <param name="numSlices">The number of slices in this chunk.</param>
-    /// <param name="acked">The boolean array containing acknowledgements of all slices.</param>
-    private void SetSliceAckData(byte chunkId, ushort numSlices, bool[] acked) {
-        _setSliceAckData(chunkId, numSlices, acked);
+    private bool IsTimedOut() {
+        if (_lastReceiveTimestamp == 0) {
+            return false;
+        }
+
+        var elapsedMillis = (Stopwatch.GetTimestamp() - _lastReceiveTimestamp) * 1000 / Stopwatch.Frequency;
+        return elapsedMillis > ReceiveTimeoutMillis;
     }
 }

--- a/SSMP/Networking/Chunk/ChunkReceiver.cs
+++ b/SSMP/Networking/Chunk/ChunkReceiver.cs
@@ -104,9 +104,9 @@ internal sealed class ChunkReceiver {
     /// </summary>
     /// <param name="sliceData">The received slice data.</param>
     public void ProcessReceivedData(SliceData sliceData) {
-        bool shouldSendAck = false;
-        bool shouldTriggerEvent = false;
-        bool isStaleDuplicate = false;
+        var shouldSendAck = false;
+        var shouldTriggerEvent = false;
+        var isStaleDuplicate = false;
         Packet.Packet? packetToTrigger = null;
 
         lock (_stateLock) {
@@ -149,13 +149,11 @@ internal sealed class ChunkReceiver {
                 return;
             }
 
-            // Ignore slices from newer chunks while the current chunk is still incomplete.
-            if (_isReceiving && _chunkId.HasValue && sliceData.ChunkId != _chunkId.Value) {
-                return;
-            }
-
-            if (!_isReceiving) {
-                if (!_chunkId.HasValue || sliceData.ChunkId != _chunkId.Value) {
+            switch (_isReceiving) {
+                // Ignore slices from newer chunks while the current chunk is still incomplete.
+                case true when _chunkId.HasValue && sliceData.ChunkId != _chunkId.Value:
+                    return;
+                case false when !_chunkId.HasValue || sliceData.ChunkId != _chunkId.Value:
                     //Logger.Debug($"Received new chunk with ID: {sliceData.ChunkId}");
                     SoftReset();
 
@@ -165,17 +163,27 @@ internal sealed class ChunkReceiver {
                     _received = new bool[_numSlices];
                     _sliceSegments = new byte[_numSlices][];
                     _lastReceiveTimestamp = Stopwatch.GetTimestamp();
-                } else if (sliceData.ChunkId == _chunkId.Value) {
-                    //Logger.Debug("Already received all slices, resending ack packet");
-                    shouldSendAck = true;
-                    isStaleDuplicate = true;
+                    break;
+                case false: {
+                    if (sliceData.ChunkId == _chunkId.Value) {
+                        //Logger.Debug("Already received all slices, resending ack packet");
+                        shouldSendAck = true;
+                        isStaleDuplicate = true;
+                    }
+
+                    break;
                 }
-            } else {
-                // If the received number of slices does not match the number slices we are keeping track of, we discard
-                // the slice altogether as it is likely not correct
-                if (_numSlices != sliceData.NumSlices) {
-                    //Logger.Debug("Number of slices in slice packet does not correspond with local number of slices");
-                    return;
+                default: {
+                    // If the received number of slices does not match the number slices we are keeping track of, we
+                    // discard
+                    // the slice altogether as it is likely not correct
+                    if (_numSlices != sliceData.NumSlices) {
+                        //Logger.Debug("Number of slices in slice packet does not correspond with local number of
+                        // slices");
+                        return;
+                    }
+
+                    break;
                 }
             }
 
@@ -257,7 +265,7 @@ internal sealed class ChunkReceiver {
     /// Send acknowledgement data containing the boolean array of all slices that have been acknowledged thus far.
     /// </summary>
     private void SendAckData() {
-        bool shouldSendAck = false;
+        var shouldSendAck = false;
         byte ackChunkId = 0;
         ushort ackNumSlices = 0;
         bool[]? ackedSlices = null;

--- a/SSMP/Networking/Chunk/ChunkSender.cs
+++ b/SSMP/Networking/Chunk/ChunkSender.cs
@@ -1,4 +1,7 @@
+// ReSharper disable InconsistentlySynchronizedField
+
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
@@ -14,35 +17,53 @@ namespace SSMP.Networking.Chunk;
 /// <param name="sliceId">The ID of the slice.</param>
 /// <param name="numSlices">The number of slices in the chunk.</param>
 /// <param name="data">The slice data.</param>
-internal delegate void SetSliceDataDelegate(byte chunkId, byte sliceId, byte numSlices, byte[] data);
+internal delegate void SetSliceDataDelegate(byte chunkId, ushort sliceId, ushort numSlices, byte[] data);
 
 /// <summary>
 /// Class that processes and manages chunks by sending slices of those chunks and receiving acknowledgements for those
 /// slices. Uses delegate injection instead of inheritance for flexibility.
 /// </summary>
-internal sealed class ChunkSender {
-    /// <summary>
-    /// The number of milliseconds to wait between sending slices.
-    /// </summary>
-    private const int WaitMillisBetweenSlices = 20;
+internal sealed class ChunkSender : IDisposable {
     /// <summary>
     /// The number of milliseconds to wait before re-sending a slice.
     /// </summary>
     private const int WaitMillisResendSlice = 100;
-    
+
+    /// <summary>
+    /// The maximum number of slices that may be in-flight for a chunk at once.
+    /// </summary>
+    private const int MaxInFlightSlices = 64;
+
+    /// <summary>
+    /// The maximum number of chunk bytes that may be in-flight at once.
+    /// </summary>
+    private const int MaxInFlightBytes = 64 * 1024;
+
     /// <summary>
     /// Blocking collection of packets that need to be sent as chunks.
     /// </summary>
     private readonly BlockingCollection<Packet.Packet> _toSendPackets;
 
     /// <summary>
-    /// Boolean array where each value indicates whether the slice of the same index was acknowledged.
+    /// Lock object for synchronizing access to shared sender state.
     /// </summary>
-    private readonly bool[] _acked;
+    private readonly object _stateLock = new();
+
     /// <summary>
-    /// Byte array that contains the chunk data that needs to be sent.
+    /// Lock object for synchronizing thread and cancellation token lifecycle (Start/Stop).
     /// </summary>
-    private readonly byte[] _chunkData;
+    private readonly object _lifecycleLock = new();
+
+    /// <summary>
+    /// Boolean array where each value indicates whether the slice of the same index was acknowledged.
+    /// Allocated dynamically for the current chunk.
+    /// </summary>
+    private bool[]? _acked;
+
+    /// <summary>
+    /// Reference to the active chunk's bytes. Stored only during active sending.
+    /// </summary>
+    private byte[]? _currentChunkData;
 
     /// <summary>
     /// Manual reset event that is used for its wait handle to time when to send the next slice.
@@ -54,37 +75,78 @@ internal sealed class ChunkSender {
     /// acknowledgements.
     /// </summary>
     private bool _isSending;
+
     /// <summary>
     /// The ID of the chunk we are currently sending.
     /// </summary>
     private byte _chunkId;
+
     /// <summary>
     /// The size of the chunk we are currently sending.
     /// </summary>
     private int _chunkSize;
+
     /// <summary>
     /// The number of slices of the chunk we are currently sending.
     /// </summary>
     private int _numSlices;
+
     /// <summary>
     /// The number of acknowledged slices in the currently sending chunk.
     /// </summary>
     private int _numAckedSlices;
+
+    /// <summary>
+    /// The number of packets enqueued for sending. Synchronized under stateLock to prevent unsynchronized concurrent collection warning.
+    /// </summary>
+    private int _queuedPacketsCount;
+
+    /// <summary>
+    /// Flag indicating whether this chunk sender has been disposed.
+    /// </summary>
+    private bool _isDisposed;
+
     /// <summary>
     /// The ID of the slice we are currently sending.
     /// </summary>
     private int _currentSliceId;
 
     /// <summary>
-    /// Array of stopwatches that keep track of the elapsed time since we have last sent the slice with the same ID.
-    /// If this time is smaller than a certain threshold, we do not send the slice again yet.
+    /// Array of millisecond timestamps (using Environment.TickCount64) representing when the slice of the same index
+    /// was last sent. Used to enforce resend pacing.
+    /// Allocated dynamically for the current chunk.
     /// </summary>
-    private readonly Stopwatch?[] _sliceStopwatches;
+    private long[]? _sliceLastSentTicks;
+
+    /// <summary>
+    /// Boolean array indicating whether a slice is currently in-flight.
+    /// </summary>
+    private bool[]? _sliceInFlight;
+
+    /// <summary>
+    /// Lengths of all slices in the current chunk.
+    /// </summary>
+    private int[]? _sliceLengths;
+
+    /// <summary>
+    /// Number of slices currently in-flight.
+    /// </summary>
+    private int _numInFlightSlices;
+
+    /// <summary>
+    /// Number of bytes currently in-flight.
+    /// </summary>
+    private int _numInFlightBytes;
 
     /// <summary>
     /// Cancellation token source for cancelling the send task.
     /// </summary>
     private CancellationTokenSource? _sendTaskTokenSource;
+
+    /// <summary>
+    /// Reference to the active sender thread.
+    /// </summary>
+    private Thread? _senderThread;
 
     /// <summary>
     /// Event that is called when we finish sending data. This is registered internally when the
@@ -103,59 +165,98 @@ internal sealed class ChunkSender {
     /// <param name="setSliceData">Delegate to call when sending slice data.</param>
     public ChunkSender(SetSliceDataDelegate setSliceData) {
         _setSliceData = setSliceData ?? throw new ArgumentNullException(nameof(setSliceData));
-        
-        _toSendPackets = new BlockingCollection<Packet.Packet>();
-        
-        _acked = new bool[ConnectionManager.MaxSlicesPerChunk];
-        _chunkData = new byte[ConnectionManager.MaxChunkSize];
-        _sliceStopwatches = new Stopwatch[ConnectionManager.MaxSlicesPerChunk];
 
+        _toSendPackets = new BlockingCollection<Packet.Packet>();
         _sliceWaitHandle = new ManualResetEventSlim();
     }
 
     /// <summary>
     /// Start the chunk sender by starting the thread that manages the chunk sending.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown if the ChunkSender has been disposed.</exception>
     public void Start() {
-        _sendTaskTokenSource?.Cancel();
-        _sendTaskTokenSource?.Dispose();
-        _sendTaskTokenSource = new CancellationTokenSource();
-        
-        Reset();
-        
-        new Thread(() => StartSends(_sendTaskTokenSource.Token)).Start();
+        lock (_lifecycleLock) {
+            lock (_stateLock) {
+                if (_isDisposed) {
+                    throw new ObjectDisposedException(
+                        nameof(ChunkSender), "Cannot start a disposed ChunkSender."
+                    );
+                }
+            }
+
+            _sendTaskTokenSource?.Cancel();
+            if (_senderThread is { IsAlive: true } && Thread.CurrentThread != _senderThread) {
+                _senderThread.Join();
+            }
+
+            _sendTaskTokenSource?.Dispose();
+            _sendTaskTokenSource = new CancellationTokenSource();
+
+            Reset();
+
+            var token = _sendTaskTokenSource.Token;
+            _senderThread = new Thread(() => StartSends(token)) {
+                IsBackground = true,
+                Name = "SSMP Chunk Sender Thread"
+            };
+            _senderThread.Start();
+        }
     }
 
     /// <summary>
     /// Stop the chunk sender by cancelling the send task.
     /// </summary>
     public void Stop() {
-        _sendTaskTokenSource?.Cancel();
-        _sendTaskTokenSource?.Dispose();
-        _sendTaskTokenSource = null;
-        
-        // Reset state to ensure clean slate on disconnect/stop
-        Reset();
+        lock (_lifecycleLock) {
+            _sendTaskTokenSource?.Cancel();
+            if (_senderThread is { IsAlive: true } && Thread.CurrentThread != _senderThread) {
+                _senderThread.Join();
+            }
+
+            _sendTaskTokenSource?.Dispose();
+            _sendTaskTokenSource = null;
+
+            // Reset state to ensure clean slate on disconnect/stop
+            Reset();
+        }
     }
-    
+
+    /// <summary>
+    /// Dispose of the chunk sender and its owned disposable resources.
+    /// </summary>
+    public void Dispose() {
+        Stop();
+        lock (_stateLock) {
+            _isDisposed = true;
+        }
+
+        _toSendPackets.Dispose();
+        _sliceWaitHandle.Dispose();
+    }
+
     /// <summary>
     /// Reset the chunk sender variables to their default values.
     /// </summary>
     private void Reset() {
-        _isSending = false;
-        _chunkId = 0;
-        _chunkSize = 0;
-        _numSlices = 0;
-        _numAckedSlices = 0;
-        _currentSliceId = 0;
+        lock (_stateLock) {
+            _isSending = false;
+            _chunkId = 0;
+            _chunkSize = 0;
+            _numSlices = 0;
+            _numAckedSlices = 0;
+            _numInFlightSlices = 0;
+            _numInFlightBytes = 0;
+            _queuedPacketsCount = 0;
+            _currentSliceId = 0;
 
-        for (var i = 0; i < _sliceStopwatches.Length; i++) {
-            _sliceStopwatches[i]?.Stop();
-            _sliceStopwatches[i] = null;
+            ReleaseArrays();
+            _currentChunkData = null;
+            FinishSendingDataEvent = null;
+
+            // Clear the blocking collection under stateLock to prevent concurrent enqueue desynchronization
+            while (_toSendPackets.TryTake(out _)) {
+            }
         }
-        
-        // Clear the blocking collection
-        while (_toSendPackets.TryTake(out _)) { }
     }
 
     /// <summary>
@@ -165,28 +266,51 @@ internal sealed class ChunkSender {
     public void FinishSendingData(Action callback) {
         // If we aren't currently sending and the queue does not contain any packets to send, we immediately invoke
         // the callback and return
-        if (!_isSending && _toSendPackets.Count == 0) {
-            callback.Invoke();
-            return;
+        var executeImmediately = false;
+        lock (_stateLock) {
+            if (!_isSending && _queuedPacketsCount == 0) {
+                executeImmediately = true;
+            } else {
+                // Otherwise, we register the event
+                // We do it like this so we can deregister the event immediately after it is called, so it doesn't
+                // trigger
+                // more than once
+                Action? lambda = null;
+                lambda = () => {
+                    callback.Invoke();
+                    lock (_stateLock) {
+                        FinishSendingDataEvent -= lambda;
+                    }
+                };
+                FinishSendingDataEvent += lambda;
+            }
         }
 
-        // Otherwise, we register the event
-        // We do it like this so we can deregister the event immediately after it is called, so it doesn't trigger
-        // more than once
-        Action? lambda = null;
-        lambda = () => {
+        if (executeImmediately) {
             callback.Invoke();
-            FinishSendingDataEvent -= lambda;
-        };
-        FinishSendingDataEvent += lambda;
+        }
     }
 
     /// <summary>
     /// Enqueue a packet to be sent as a chunk.
     /// </summary>
     /// <param name="packet">The packet to send.</param>
+    /// <exception cref="ArgumentNullException">Thrown if the packet is null.</exception>
     public void EnqueuePacket(Packet.Packet packet) {
-        _toSendPackets.Add(packet);
+        if (packet == null) {
+            throw new ArgumentNullException(nameof(packet), "Cannot enqueue a null packet.");
+        }
+
+        lock (_stateLock) {
+            if (_isDisposed) {
+                throw new ObjectDisposedException(
+                    nameof(ChunkSender), "Cannot enqueue packets to a disposed ChunkSender."
+                );
+            }
+
+            _queuedPacketsCount++;
+            _toSendPackets.Add(packet);
+        }
     }
 
     /// <summary>
@@ -199,27 +323,45 @@ internal sealed class ChunkSender {
     public void ProcessReceivedData(SliceAckData sliceAckData) {
         //Logger.Debug($"Received slice ack packet: {sliceAckData.ChunkId}, {sliceAckData.NumSlices}");
 
-        if (!_isSending) {
-            //Logger.Debug("Not sending a chunk, ignoring ack packet");
-            return;
-        }
+        lock (_stateLock) {
+            if (!_isSending || _acked == null) {
+                //Logger.Debug("Not sending a chunk, ignoring ack packet");
+                return;
+            }
 
-        if (_chunkId != sliceAckData.ChunkId) {
-            //Logger.Debug("Chunk ID of received ack packet does not correspond with currently sending chunk");
-            return;
-        }
+            if (_chunkId != sliceAckData.ChunkId) {
+                //Logger.Debug("Chunk ID of received ack packet does not correspond with currently sending chunk");
+                return;
+            }
 
-        if (_numSlices != sliceAckData.NumSlices) {
-            //Logger.Debug("Number of slices in ack packet does not correspond with local number of slices");
-            return;
-        }
+            if (_numSlices != sliceAckData.NumSlices) {
+                //Logger.Debug("Number of slices in ack packet does not correspond with local number of slices");
+                return;
+            }
 
-        for (var i = 0; i < _numSlices; i++) {
-            if (sliceAckData.Acked[i] && !_acked[i]) {
+            var newAckProcessed = false;
+            for (var i = 0; i < _numSlices; i++) {
+                if (!sliceAckData.Acked[i] || _acked[i]) {
+                    continue;
+                }
+
                 _acked[i] = true;
                 _numAckedSlices += 1;
-                
+                if (_sliceInFlight != null && _sliceInFlight[i]) {
+                    _sliceInFlight[i] = false;
+                    _numInFlightSlices -= 1;
+                    if (_sliceLengths != null) {
+                        _numInFlightBytes -= _sliceLengths[i];
+                    }
+                }
+
+                newAckProcessed = true;
+
                 //Logger.Debug($"Received acknowledgement for slice {i}, total acked: {_numAckedSlices}");
+            }
+
+            if (newAckProcessed) {
+                _sliceWaitHandle.Set();
             }
         }
     }
@@ -235,89 +377,137 @@ internal sealed class ChunkSender {
     /// </summary>
     /// <param name="cancellationToken">The cancellation token for cancelling the sending process.</param>
     private void StartSends(CancellationToken cancellationToken) {
-        while (!cancellationToken.IsCancellationRequested) {
-            if (_toSendPackets.Count == 0) {
-                FinishSendingDataEvent?.Invoke();
-            }
-
-            Packet.Packet packet;
-            try {
-                packet = _toSendPackets.Take(cancellationToken);
-            } catch (OperationCanceledException) {
-                continue;
-            }
-
-            _isSending = true;
-
-            //Logger.Debug("Successfully taken new packet from blocking collection, starting networking chunk");
-
-            Array.Clear(_sliceStopwatches, 0, _sliceStopwatches.Length);
-            Array.Clear(_acked, 0, _acked.Length);
-            _numAckedSlices = 0;
-
-            var packetBytes = packet.ToArray();
-
-            _chunkSize = packetBytes.Length;
-            _numSlices = _chunkSize / ConnectionManager.MaxSliceSize;
-            if (_chunkSize % ConnectionManager.MaxSliceSize != 0) {
-                _numSlices += 1;
-            }
-
-            //Logger.Debug($"ChunkSize: {_chunkSize}, NumSlices: {_numSlices}");
-
-            // Skip over chunks that exceed the maximum size that our system can handle
-            if (_chunkSize > ConnectionManager.MaxChunkSize) {
-                Logger.Error($"Could not send packet that exceeds max chunk size: {_chunkSize}");
-                continue;
-            }
-
-            // Copy the raw bytes from the packet into the chunk data array
-            Array.Copy(packetBytes, _chunkData, _chunkSize);
-
-            do {
-                //Logger.Debug($"Sending next slice: {_currentSliceId}");
-                SendNextSlice();
-
-                // Obtain (or create) the stopwatch for the slice and start it
-                var sliceStopwatch = _sliceStopwatches[_currentSliceId];
-                if (sliceStopwatch == null) {
-                    sliceStopwatch = new Stopwatch();
-                    _sliceStopwatches[_currentSliceId] = sliceStopwatch;
-                }
-
-                sliceStopwatch.Restart();
-
-                if (!TryGetNextSliceToSend()) {
-                    //Logger.Debug($"All slices have been acked ({_numAckedSlices}), stopping sending slices");
-                    break;
-                }
-
-                long waitMillisNextSlice;
-
-                // Get the stopwatch for this slice, and check whether we have already sent this slice not too long ago
-                // If so, we wait longer before resending the slice. Otherwise, we default to the normal send rate.
-                sliceStopwatch = _sliceStopwatches[_currentSliceId];
-                if (sliceStopwatch == null) {
-                    waitMillisNextSlice = WaitMillisBetweenSlices;
-                } else {
-                    waitMillisNextSlice = WaitMillisResendSlice - sliceStopwatch.ElapsedMilliseconds;
-                    if (waitMillisNextSlice < 0) {
-                        waitMillisNextSlice = WaitMillisBetweenSlices;
+        try {
+            while (!cancellationToken.IsCancellationRequested) {
+                Action? eventToInvoke = null;
+                lock (_stateLock) {
+                    if (_queuedPacketsCount == 0) {
+                        eventToInvoke = FinishSendingDataEvent;
                     }
                 }
 
-                //Logger.Debug($"Waiting on handle for next slice: {waitMillisNextSlice}");
+                eventToInvoke?.Invoke();
+
+                Packet.Packet packet;
                 try {
-                    _sliceWaitHandle.Wait((int) waitMillisNextSlice, cancellationToken);
+                    packet = _toSendPackets.Take(cancellationToken);
                 } catch (OperationCanceledException) {
-                    //Logger.Debug("Wait operation was cancelled, breaking");
+                    continue;
+                }
+
+                //Logger.Debug("Successfully taken new packet from blocking collection, starting networking chunk");
+
+                var decremented = false;
+                try {
+                    var packetBytes = packet.ToArray();
+
+                    switch (packetBytes.Length) {
+                        // Skip over chunks that exceed the maximum size that our system can handle
+                        case > ConnectionManager.MaxChunkSize: {
+                            Logger.Error($"Could not send packet that exceeds max chunk size: {packetBytes.Length}");
+                            lock (_stateLock) {
+                                _queuedPacketsCount--;
+                                decremented = true;
+                            }
+
+                            continue;
+                        }
+                        case 0: {
+                            Logger.Error("Cannot send an empty chunk packet.");
+                            lock (_stateLock) {
+                                _queuedPacketsCount--;
+                                decremented = true;
+                            }
+
+                            continue;
+                        }
+                    }
+
+                    lock (_stateLock) {
+                        _queuedPacketsCount--;
+                        decremented = true;
+                        _chunkSize = packetBytes.Length;
+                        _numSlices = _chunkSize / ConnectionManager.MaxSliceSize;
+                        if (_chunkSize % ConnectionManager.MaxSliceSize != 0) {
+                            _numSlices += 1;
+                        }
+
+                        _isSending = true;
+                        _acked = ArrayPool<bool>.Shared.Rent(_numSlices);
+                        _sliceLastSentTicks = ArrayPool<long>.Shared.Rent(_numSlices);
+                        _sliceInFlight = ArrayPool<bool>.Shared.Rent(_numSlices);
+                        _sliceLengths = ArrayPool<int>.Shared.Rent(_numSlices);
+                        Array.Clear(_acked, 0, _numSlices);
+                        Array.Clear(_sliceLastSentTicks, 0, _numSlices);
+                        Array.Clear(_sliceInFlight, 0, _numSlices);
+                        _numAckedSlices = 0;
+                        _numInFlightSlices = 0;
+                        _numInFlightBytes = 0;
+                        _currentSliceId = 0;
+
+                        for (var sliceId = 0; sliceId < _numSlices; sliceId++) {
+                            var startIndex = sliceId * ConnectionManager.MaxSliceSize;
+                            _sliceLengths[sliceId] = System.Math.Min(
+                                ConnectionManager.MaxSliceSize,
+                                _chunkSize - startIndex
+                            );
+                        }
+
+                        // Reference the raw bytes from the packet dynamically
+                        _currentChunkData = packetBytes;
+                    }
+                } catch (Exception ex) {
+                    Logger.Error($"Error serializing packet for chunk sending: {ex.Message}");
+                    lock (_stateLock) {
+                        if (!decremented) {
+                            _queuedPacketsCount--;
+                        }
+
+                        ReleaseArrays();
+                        _currentChunkData = null;
+                        _isSending = false;
+                    }
+
+                    continue;
+                }
+
+                do {
+                    _sliceWaitHandle.Reset();
+
+                    if (TryGetNextSliceToSend(out var waitMillisNextSlice, out var completed)) {
+                        SendNextSlice();
+                        continue;
+                    }
+
+                    if (completed) {
+                        break;
+                    }
+
+                    try {
+                        _sliceWaitHandle.Wait(waitMillisNextSlice, cancellationToken);
+                    } catch (OperationCanceledException) {
+                        break;
+                    }
+                } while (!cancellationToken.IsCancellationRequested);
+
+                if (cancellationToken.IsCancellationRequested) {
                     break;
                 }
-            } while (!cancellationToken.IsCancellationRequested);
 
-            //Logger.Debug($"Incrementing chunk ID to: {_chunkId + 1}");
-            _chunkId += 1;
-            _isSending = false;
+                //Logger.Debug($"Incrementing chunk ID to: {_chunkId + 1}");
+                lock (_stateLock) {
+                    _chunkId += 1;
+                    ReleaseArrays();
+                    _currentChunkData = null;
+                    _isSending = false;
+                }
+            }
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Logger.Error($"Fatal error in SSMP Chunk Sender background thread: {ex.Message}\n{ex.StackTrace}");
+        } finally {
+            lock (_stateLock) {
+                ReleaseArrays();
+            }
         }
     }
 
@@ -326,23 +516,46 @@ internal sealed class ChunkSender {
     /// data in the array and copy the data into a new array for adding to the update packet.
     /// </summary>
     private void SendNextSlice() {
-        var startIndex = _currentSliceId * ConnectionManager.MaxSliceSize;
-        
-        byte[] sliceBytes;
-        // Figure out if the start index for the next slice would exceed the chunk size. If so, the length of the slice
-        // is less than the maximum slice size, which we need to calculate
-        if ((_currentSliceId + 1) * ConnectionManager.MaxSliceSize > _chunkSize) {
-            var length = _chunkSize - startIndex;
-            sliceBytes = new byte[length];
-            
-            Array.Copy(_chunkData, startIndex, sliceBytes, 0, length);
-        } else {
-            sliceBytes = new byte[ConnectionManager.MaxSliceSize];
-            
-            Array.Copy(_chunkData, startIndex, sliceBytes, 0, sliceBytes.Length);
+        byte[]? currentChunkData;
+        int currentSliceId;
+        int numSlices;
+        byte chunkId;
+        int chunkSize;
+
+        lock (_stateLock) {
+            if (_currentChunkData == null) return;
+            currentChunkData = _currentChunkData;
+            currentSliceId = _currentSliceId;
+            numSlices = _numSlices;
+            chunkId = _chunkId;
+            chunkSize = _chunkSize;
         }
 
-        SetSliceData(_chunkId, (byte) _currentSliceId, (byte) _numSlices, sliceBytes);
+        var startIndex = currentSliceId * ConnectionManager.MaxSliceSize;
+
+        int sliceLength;
+        // Figure out if the start index for the next slice would exceed the chunk size. If so, the length of the slice
+        // is less than the maximum slice size, which we need to calculate
+        if ((currentSliceId + 1) * ConnectionManager.MaxSliceSize > chunkSize) {
+            sliceLength = chunkSize - startIndex;
+        } else {
+            sliceLength = ConnectionManager.MaxSliceSize;
+        }
+
+        var sliceBytes = new byte[sliceLength];
+        Array.Copy(currentChunkData, startIndex, sliceBytes, 0, sliceLength);
+
+        lock (_stateLock) {
+            if (_sliceInFlight != null && !_sliceInFlight[currentSliceId]) {
+                _sliceInFlight[currentSliceId] = true;
+                _numInFlightSlices += 1;
+                _numInFlightBytes += sliceLength;
+            }
+
+            _sliceLastSentTicks?[currentSliceId] = Stopwatch.GetTimestamp();
+        }
+
+        _setSliceData(chunkId, (ushort) currentSliceId, (ushort) numSlices, sliceBytes);
     }
 
     /// <summary>
@@ -351,31 +564,93 @@ internal sealed class ChunkSender {
     /// equals the number of slices in the chunk, so we don't end up in an infinite loop.
     /// </summary>
     /// <returns>True if a next slice could be found, false if all slices are acknowledged.</returns>
-    private bool TryGetNextSliceToSend() {
-        do {
-            // We do the check inside the loop to prevent multi-thread issues where another ack is received and
-            // a non-acked slice cannot be found anywhere, resulting in an infinite while loop
-            if (_numAckedSlices == _numSlices) {
+    private bool TryGetNextSliceToSend(out int waitMillis, out bool completed) {
+        lock (_stateLock) {
+            waitMillis = Timeout.Infinite;
+            completed = false;
+
+            if (_acked == null || _sliceLengths == null || _sliceInFlight == null) {
                 return false;
             }
 
-            _currentSliceId += 1;
-            if (_currentSliceId >= _numSlices) {
-                _currentSliceId = 0;
+            if (_numAckedSlices == _numSlices) {
+                completed = true;
+                return false;
             }
-        } while (_acked[_currentSliceId]);
 
-        return true;
+            for (var offset = 1; offset <= _numSlices; offset++) {
+                var candidateSliceId = (_currentSliceId + offset) % _numSlices;
+                if (_acked[candidateSliceId]) {
+                    continue;
+                }
+
+                var sliceLength = _sliceLengths[candidateSliceId];
+                if (_sliceInFlight[candidateSliceId]) {
+                    if (_sliceLastSentTicks == null) {
+                        continue;
+                    }
+
+                    var lastSent = _sliceLastSentTicks[candidateSliceId];
+                    var elapsedMillis = lastSent == 0
+                        ? WaitMillisResendSlice
+                        : (Stopwatch.GetTimestamp() - lastSent) * 1000 / Stopwatch.Frequency;
+                    var remainingMillis = WaitMillisResendSlice - (int) elapsedMillis;
+                    if (remainingMillis <= 0) {
+                        _currentSliceId = candidateSliceId;
+                        return true;
+                    }
+
+                    waitMillis = waitMillis == Timeout.Infinite
+                        ? remainingMillis
+                        : System.Math.Min(waitMillis, remainingMillis);
+                    continue;
+                }
+
+                if (!HasWindowCapacity(sliceLength)) {
+                    continue;
+                }
+
+                _currentSliceId = candidateSliceId;
+                return true;
+            }
+
+            return false;
+        }
     }
 
     /// <summary>
-    /// Send the given slice data using the injected delegate.
+    /// Return the rented ack and pacing arrays to the Shared ArrayPool.
     /// </summary>
-    /// <param name="chunkId">The ID of the chunk for this slice.</param>
-    /// <param name="sliceId">The ID of the slice.</param>
-    /// <param name="numSlices">The number of slices in this chunk.</param>
-    /// <param name="data">The byte array containing the data of the slice.</param>
-    private void SetSliceData(byte chunkId, byte sliceId, byte numSlices, byte[] data) {
-        _setSliceData(chunkId, sliceId, numSlices, data);
+    private void ReleaseArrays() {
+        if (_acked != null) {
+            ArrayPool<bool>.Shared.Return(_acked);
+            _acked = null;
+        }
+
+        if (_sliceLastSentTicks != null) {
+            ArrayPool<long>.Shared.Return(_sliceLastSentTicks);
+            _sliceLastSentTicks = null;
+        }
+
+        if (_sliceInFlight != null) {
+            ArrayPool<bool>.Shared.Return(_sliceInFlight);
+            _sliceInFlight = null;
+        }
+
+        if (_sliceLengths != null) {
+            ArrayPool<int>.Shared.Return(_sliceLengths);
+            _sliceLengths = null;
+        }
+
+        _numInFlightSlices = 0;
+        _numInFlightBytes = 0;
+    }
+
+    /// <summary>
+    /// Checks whether the sender can emit a new slice without exceeding the in-flight window.
+    /// </summary>
+    private bool HasWindowCapacity(int sliceLength) {
+        return _numInFlightSlices < MaxInFlightSlices &&
+               _numInFlightBytes + sliceLength <= MaxInFlightBytes;
     }
 }

--- a/SSMP/Networking/Chunk/ChunkSender.cs
+++ b/SSMP/Networking/Chunk/ChunkSender.cs
@@ -97,7 +97,8 @@ internal sealed class ChunkSender : IDisposable {
     private int _numAckedSlices;
 
     /// <summary>
-    /// The number of packets enqueued for sending. Synchronized under stateLock to prevent unsynchronized concurrent collection warning.
+    /// The number of packets enqueued for sending. Synchronized under stateLock to prevent unsynchronized concurrent
+    /// collection warning.
     /// </summary>
     private int _queuedPacketsCount;
 
@@ -150,7 +151,7 @@ internal sealed class ChunkSender : IDisposable {
 
     /// <summary>
     /// Event that is called when we finish sending data. This is registered internally when the
-    /// <see cref="FinishSendingData"/> method is called and we are waiting for the current chunk to finish sending.
+    /// <see cref="FinishSendingData"/> method is called, and we are waiting for the current chunk to finish sending.
     /// </summary>
     private event Action? FinishSendingDataEvent;
 
@@ -555,7 +556,7 @@ internal sealed class ChunkSender : IDisposable {
             _sliceLastSentTicks?[currentSliceId] = Stopwatch.GetTimestamp();
         }
 
-        _setSliceData(chunkId, (ushort) currentSliceId, (ushort) numSlices, sliceBytes);
+        _setSliceData.Invoke(chunkId, (ushort) currentSliceId, (ushort) numSlices, sliceBytes);
     }
 
     /// <summary>

--- a/SSMP/Networking/Chunk/ChunkSender.cs
+++ b/SSMP/Networking/Chunk/ChunkSender.cs
@@ -297,7 +297,7 @@ internal sealed class ChunkSender : IDisposable {
     /// </summary>
     /// <param name="packet">The packet to send.</param>
     /// <exception cref="ArgumentNullException">Thrown if the packet is null.</exception>
-    /// <exception cref="ObjectDisposedException"> Thrown if the ChunkSender has been disposed. </exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the ChunkSender has been disposed.</exception>
     public void EnqueuePacket(Packet.Packet packet) {
         if (packet == null) {
             throw new ArgumentNullException(nameof(packet), "Cannot enqueue a null packet.");

--- a/SSMP/Networking/Chunk/ChunkSender.cs
+++ b/SSMP/Networking/Chunk/ChunkSender.cs
@@ -297,6 +297,7 @@ internal sealed class ChunkSender : IDisposable {
     /// </summary>
     /// <param name="packet">The packet to send.</param>
     /// <exception cref="ArgumentNullException">Thrown if the packet is null.</exception>
+    /// <exception cref="ObjectDisposedException"> Thrown if the ChunkSender has been disposed. </exception>
     public void EnqueuePacket(Packet.Packet packet) {
         if (packet == null) {
             throw new ArgumentNullException(nameof(packet), "Cannot enqueue a null packet.");
@@ -380,128 +381,25 @@ internal sealed class ChunkSender : IDisposable {
     private void StartSends(CancellationToken cancellationToken) {
         try {
             while (!cancellationToken.IsCancellationRequested) {
-                Action? eventToInvoke = null;
-                lock (_stateLock) {
-                    if (_queuedPacketsCount == 0) {
-                        eventToInvoke = FinishSendingDataEvent;
-                    }
-                }
+                InvokeFinishCallbackIfIdle();
 
-                eventToInvoke?.Invoke();
-
-                Packet.Packet packet;
-                try {
-                    packet = _toSendPackets.Take(cancellationToken);
-                } catch (OperationCanceledException) {
+                if (!TryTakeNextPacket(cancellationToken, out var packet)) {
                     continue;
                 }
 
                 //Logger.Debug("Successfully taken new packet from blocking collection, starting networking chunk");
 
-                var decremented = false;
-                try {
-                    var packetBytes = packet.ToArray();
-
-                    switch (packetBytes.Length) {
-                        // Skip over chunks that exceed the maximum size that our system can handle
-                        case > ConnectionManager.MaxChunkSize: {
-                            Logger.Error($"Could not send packet that exceeds max chunk size: {packetBytes.Length}");
-                            lock (_stateLock) {
-                                _queuedPacketsCount--;
-                                decremented = true;
-                            }
-
-                            continue;
-                        }
-                        case 0: {
-                            Logger.Error("Cannot send an empty chunk packet.");
-                            lock (_stateLock) {
-                                _queuedPacketsCount--;
-                                decremented = true;
-                            }
-
-                            continue;
-                        }
-                    }
-
-                    lock (_stateLock) {
-                        _queuedPacketsCount--;
-                        decremented = true;
-                        _chunkSize = packetBytes.Length;
-                        _numSlices = _chunkSize / ConnectionManager.MaxSliceSize;
-                        if (_chunkSize % ConnectionManager.MaxSliceSize != 0) {
-                            _numSlices += 1;
-                        }
-
-                        _isSending = true;
-                        _acked = ArrayPool<bool>.Shared.Rent(_numSlices);
-                        _sliceLastSentTicks = ArrayPool<long>.Shared.Rent(_numSlices);
-                        _sliceInFlight = ArrayPool<bool>.Shared.Rent(_numSlices);
-                        _sliceLengths = ArrayPool<int>.Shared.Rent(_numSlices);
-                        Array.Clear(_acked, 0, _numSlices);
-                        Array.Clear(_sliceLastSentTicks, 0, _numSlices);
-                        Array.Clear(_sliceInFlight, 0, _numSlices);
-                        _numAckedSlices = 0;
-                        _numInFlightSlices = 0;
-                        _numInFlightBytes = 0;
-                        _currentSliceId = 0;
-
-                        for (var sliceId = 0; sliceId < _numSlices; sliceId++) {
-                            var startIndex = sliceId * ConnectionManager.MaxSliceSize;
-                            _sliceLengths[sliceId] = System.Math.Min(
-                                ConnectionManager.MaxSliceSize,
-                                _chunkSize - startIndex
-                            );
-                        }
-
-                        // Reference the raw bytes from the packet dynamically
-                        _currentChunkData = packetBytes;
-                    }
-                } catch (Exception ex) {
-                    Logger.Error($"Error serializing packet for chunk sending: {ex.Message}");
-                    lock (_stateLock) {
-                        if (!decremented) {
-                            _queuedPacketsCount--;
-                        }
-
-                        ReleaseArrays();
-                        _currentChunkData = null;
-                        _isSending = false;
-                    }
-
+                if (!TryPrepareChunkForSending(packet)) {
                     continue;
                 }
 
-                do {
-                    _sliceWaitHandle.Reset();
-
-                    if (TryGetNextSliceToSend(out var waitMillisNextSlice, out var completed)) {
-                        SendNextSlice();
-                        continue;
-                    }
-
-                    if (completed) {
-                        break;
-                    }
-
-                    try {
-                        _sliceWaitHandle.Wait(waitMillisNextSlice, cancellationToken);
-                    } catch (OperationCanceledException) {
-                        break;
-                    }
-                } while (!cancellationToken.IsCancellationRequested);
+                RunSliceSendLoop(cancellationToken);
 
                 if (cancellationToken.IsCancellationRequested) {
                     break;
                 }
 
-                //Logger.Debug($"Incrementing chunk ID to: {_chunkId + 1}");
-                lock (_stateLock) {
-                    _chunkId += 1;
-                    ReleaseArrays();
-                    _currentChunkData = null;
-                    _isSending = false;
-                }
+                AdvanceToNextChunk();
             }
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             Logger.Error($"Fatal error in SSMP Chunk Sender background thread: {ex.Message}\n{ex.StackTrace}");
@@ -509,6 +407,162 @@ internal sealed class ChunkSender : IDisposable {
             lock (_stateLock) {
                 ReleaseArrays();
             }
+        }
+    }
+
+    /// <summary>
+    /// If there are no packets currently queued, captures and invokes the registered
+    /// <see cref="FinishSendingDataEvent"/> so subscribers are notified that the sender has gone idle.
+    /// </summary>
+    private void InvokeFinishCallbackIfIdle() {
+        Action? eventToInvoke = null;
+        lock (_stateLock) {
+            if (_queuedPacketsCount == 0) {
+                eventToInvoke = FinishSendingDataEvent;
+            }
+        }
+
+        eventToInvoke?.Invoke();
+    }
+
+    /// <summary>
+    /// Blocks on <see cref="_toSendPackets"/> until a packet is available or the token is cancelled.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the blocking take.</param>
+    /// <param name="packet">The packet taken from the queue, if successful.</param>
+    /// <returns>False if the take was cancelled before a packet became available.</returns>
+    private bool TryTakeNextPacket(CancellationToken cancellationToken, out Packet.Packet packet) {
+        try {
+            packet = _toSendPackets.Take(cancellationToken);
+            return true;
+        } catch (OperationCanceledException) {
+            packet = null!;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Serializes the packet and initializes all per-chunk sending state (slice count, rented pacing/ack arrays,
+    /// slice length table). On any validation failure or exception, cleans up after itself and decrements the
+    /// queued-packet count exactly once.
+    /// </summary>
+    /// <param name="packet">The packet to prepare for chunked sending.</param>
+    /// <returns>True if the chunk is ready to send; false if it was rejected or failed to serialize.</returns>
+    private bool TryPrepareChunkForSending(Packet.Packet packet) {
+        var decremented = false;
+        try {
+            var packetBytes = packet.ToArray();
+
+            switch (packetBytes.Length) {
+                // Skip over chunks that exceed the maximum size that our system can handle
+                case > ConnectionManager.MaxChunkSize: {
+                    Logger.Error($"Could not send packet that exceeds max chunk size: {packetBytes.Length}");
+                    lock (_stateLock) {
+                        _queuedPacketsCount--;
+                        decremented = true;
+                    }
+
+                    return false;
+                }
+                case 0: {
+                    Logger.Error("Cannot send an empty chunk packet.");
+                    lock (_stateLock) {
+                        _queuedPacketsCount--;
+                        decremented = true;
+                    }
+
+                    return false;
+                }
+            }
+
+            lock (_stateLock) {
+                _queuedPacketsCount--;
+                decremented = true;
+                _chunkSize = packetBytes.Length;
+                _numSlices = _chunkSize / ConnectionManager.MaxSliceSize;
+                if (_chunkSize % ConnectionManager.MaxSliceSize != 0) {
+                    _numSlices += 1;
+                }
+
+                _isSending = true;
+                _acked = ArrayPool<bool>.Shared.Rent(_numSlices);
+                _sliceLastSentTicks = ArrayPool<long>.Shared.Rent(_numSlices);
+                _sliceInFlight = ArrayPool<bool>.Shared.Rent(_numSlices);
+                _sliceLengths = ArrayPool<int>.Shared.Rent(_numSlices);
+                Array.Clear(_acked, 0, _numSlices);
+                Array.Clear(_sliceLastSentTicks, 0, _numSlices);
+                Array.Clear(_sliceInFlight, 0, _numSlices);
+                _numAckedSlices = 0;
+                _numInFlightSlices = 0;
+                _numInFlightBytes = 0;
+                _currentSliceId = 0;
+
+                for (var sliceId = 0; sliceId < _numSlices; sliceId++) {
+                    var startIndex = sliceId * ConnectionManager.MaxSliceSize;
+                    _sliceLengths[sliceId] = System.Math.Min(
+                        ConnectionManager.MaxSliceSize,
+                        _chunkSize - startIndex
+                    );
+                }
+
+                // Reference the raw bytes from the packet dynamically
+                _currentChunkData = packetBytes;
+            }
+
+            return true;
+        } catch (Exception ex) {
+            Logger.Error($"Error serializing packet for chunk sending: {ex.Message}");
+            lock (_stateLock) {
+                if (!decremented) {
+                    _queuedPacketsCount--;
+                }
+
+                ReleaseArrays();
+                _currentChunkData = null;
+                _isSending = false;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Repeatedly sends the next due slice of the chunk currently being prepared, pacing resends and waiting
+    /// between attempts, until every slice has been acknowledged or the token is cancelled.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel sending and the inter-slice wait.</param>
+    private void RunSliceSendLoop(CancellationToken cancellationToken) {
+        do {
+            _sliceWaitHandle.Reset();
+
+            if (TryGetNextSliceToSend(out var waitMillisNextSlice, out var completed)) {
+                SendNextSlice();
+                continue;
+            }
+
+            if (completed) {
+                break;
+            }
+
+            try {
+                _sliceWaitHandle.Wait(waitMillisNextSlice, cancellationToken);
+            } catch (OperationCanceledException) {
+                break;
+            }
+        } while (!cancellationToken.IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// Advances to the next chunk ID and releases all per-chunk sending state now that the current chunk has
+    /// finished sending (fully acknowledged). Must only be called when not cancelled.
+    /// </summary>
+    private void AdvanceToNextChunk() {
+        //Logger.Debug($"Incrementing chunk ID to: {_chunkId + 1}");
+        lock (_stateLock) {
+            _chunkId += 1;
+            ReleaseArrays();
+            _currentChunkData = null;
+            _isSending = false;
         }
     }
 

--- a/SSMP/Networking/Client/ClientConnectionManager.cs
+++ b/SSMP/Networking/Client/ClientConnectionManager.cs
@@ -28,6 +28,11 @@ internal class ClientConnectionManager : ConnectionManager {
     public event Action<ServerInfo>? ServerInfoReceivedEvent;
 
     /// <summary>
+    /// Whether chunked addon payloads are allowed to be dispatched yet.
+    /// </summary>
+    public bool AllowAddonChunks { get; set; }
+
+    /// <summary>
     ///     Construct the connection manager with the given packet manager and chunk sender, and receiver instances.
     ///     Will register handlers in the packet manager that relate to the connection.
     /// </summary>
@@ -102,7 +107,32 @@ internal class ClientConnectionManager : ConnectionManager {
             return;
         }
 
-        // Let the packet manager handle the connection packet, which will invoke the relevant data handlers
-        PacketManager.HandleClientConnectionPacket(connectionPacket);
+        var packetData = connectionPacket.GetPacketData();
+        if (packetData.ContainsKey(ClientConnectionPacketId.ServerInfo)) {
+            PacketManager.HandleClientConnectionPacket(connectionPacket);
+            return;
+        }
+
+        if (!packetData.TryGetValue(ClientConnectionPacketId.ChunkAddonData, out var chunkAddonDataRaw)) {
+            Logger.Debug("Received unexpected connection chunk packet with no supported payload");
+            return;
+        }
+
+        if (!AllowAddonChunks) {
+            Logger.Warn("Discarded chunked addon payload before the client completed connection setup");
+            return;
+        }
+
+        var chunkAddonData = (ChunkAddonData) chunkAddonDataRaw;
+        if (!ClientConnectionPacket.AddonPacketInfoDict.TryGetValue(chunkAddonData.AddonId, out var addonPacketInfo)) {
+            Logger.Warn($"Received chunked addon payload for unknown addon ID {chunkAddonData.AddonId}");
+            return;
+        }
+
+        var packetDataInstance = addonPacketInfo.PacketDataInstantiator.Invoke(chunkAddonData.PacketId);
+        packetDataInstance.ReadData(new Packet.Packet(chunkAddonData.Payload));
+        PacketManager.HandleClientAddonPacketSingle(
+            chunkAddonData.AddonId, chunkAddonData.PacketId, packetDataInstance
+        );
     }
 }

--- a/SSMP/Networking/Client/ClientConnectionManager.cs
+++ b/SSMP/Networking/Client/ClientConnectionManager.cs
@@ -9,8 +9,12 @@ using SSMP.Networking.Packet.Data;
 namespace SSMP.Networking.Client;
 
 /// <summary>
-/// Client-side manager for handling the initial connection to the server.
+/// Client-side manager for handling connection-phase traffic.
 /// </summary>
+/// <remarks>
+/// Also handles chunked addon payloads after connection setup. We deliberately reused the
+/// existing connection-packet chunking path instead of introducing a separate transport path.
+/// </remarks>
 internal class ClientConnectionManager : ConnectionManager {
     /// <summary>
     /// The client-side chunk sender used to handle sending chunks.
@@ -28,13 +32,13 @@ internal class ClientConnectionManager : ConnectionManager {
     public event Action<ServerInfo>? ServerInfoReceivedEvent;
 
     /// <summary>
-    /// Whether chunked addon payloads are allowed to be dispatched yet.
+    /// Whether post-setup chunked addon payloads are allowed to be dispatched yet.
     /// </summary>
     public bool AllowAddonChunks { get; set; }
 
     /// <summary>
     /// Construct the connection manager with the given packet manager and chunk sender, and receiver instances.
-    /// Will register handlers in the packet manager that relate to the connection.
+    /// Will register handlers for handshake traffic and for the reused connection-packet chunk transport.
     /// </summary>
     public ClientConnectionManager(
         PacketManager packetManager,
@@ -64,7 +68,7 @@ internal class ClientConnectionManager : ConnectionManager {
         string authKey,
         List<AddonData> addonData
     ) {
-        // Create a connection packet that will be the entire chunk we will be sending
+        // Create the connection packet that will be chunk-transported to the server.
         var connectionPacket = new ServerConnectionPacket();
 
         // Set the client info data in the connection packet
@@ -80,8 +84,8 @@ internal class ClientConnectionManager : ConnectionManager {
         var packet = new Packet.Packet();
         connectionPacket.CreatePacket(packet);
 
-        // All transports use ChunkSender for connection packets
-        // This ensures consistent handling on the server side via ChunkReceiver
+        // All transports use ChunkSender for connection packets.
+        // This same chunk path is intentionally reused later for oversized addon payloads.
         _chunkSender.EnqueuePacket(packet);
     }
 
@@ -96,7 +100,8 @@ internal class ClientConnectionManager : ConnectionManager {
     }
 
     /// <summary>
-    /// Callback method for when a new chunk is received from the server.
+    /// Callback method for when a new connection-phase chunk is received from the server.
+    /// This covers both handshake packets and the deliberate reuse of connection packets for chunked addon payloads.
     /// </summary>
     /// <param name="packet">The raw packet that contains the data from the chunk.</param>
     private void OnChunkReceived(Packet.Packet packet) {

--- a/SSMP/Networking/Client/ClientConnectionManager.cs
+++ b/SSMP/Networking/Client/ClientConnectionManager.cs
@@ -9,21 +9,21 @@ using SSMP.Networking.Packet.Data;
 namespace SSMP.Networking.Client;
 
 /// <summary>
-///     Client-side manager for handling the initial connection to the server.
+/// Client-side manager for handling the initial connection to the server.
 /// </summary>
 internal class ClientConnectionManager : ConnectionManager {
     /// <summary>
-    ///     The client-side chunk sender used to handle sending chunks.
+    /// The client-side chunk sender used to handle sending chunks.
     /// </summary>
     private readonly ChunkSender _chunkSender;
 
     /// <summary>
-    ///     The client-side chunk received used to receive chunks.
+    /// The client-side chunk received used to receive chunks.
     /// </summary>
     private readonly ChunkReceiver _chunkReceiver;
 
     /// <summary>
-    ///     Event that is called when server info is received from the server we are trying to connect to.
+    /// Event that is called when server info is received from the server we are trying to connect to.
     /// </summary>
     public event Action<ServerInfo>? ServerInfoReceivedEvent;
 
@@ -33,8 +33,8 @@ internal class ClientConnectionManager : ConnectionManager {
     public bool AllowAddonChunks { get; set; }
 
     /// <summary>
-    ///     Construct the connection manager with the given packet manager and chunk sender, and receiver instances.
-    ///     Will register handlers in the packet manager that relate to the connection.
+    /// Construct the connection manager with the given packet manager and chunk sender, and receiver instances.
+    /// Will register handlers in the packet manager that relate to the connection.
     /// </summary>
     public ClientConnectionManager(
         PacketManager packetManager,
@@ -52,12 +52,12 @@ internal class ClientConnectionManager : ConnectionManager {
     }
 
     /// <summary>
-    ///     Start establishing the connection to the server with the given information.
+    /// Start establishing the connection to the server with the given information.
     /// </summary>
     /// <param name="username">The username of the player.</param>
     /// <param name="authKey">The authentication key of the player.</param>
     /// <param name="addonData">
-    ///     List of addon data that represents the enabled networked addons that the client uses.
+    /// List of addon data that represents the enabled networked addons that the client uses.
     /// </param>
     public void StartConnection(
         string username,
@@ -96,7 +96,7 @@ internal class ClientConnectionManager : ConnectionManager {
     }
 
     /// <summary>
-    ///     Callback method for when a new chunk is received from the server.
+    /// Callback method for when a new chunk is received from the server.
     /// </summary>
     /// <param name="packet">The raw packet that contains the data from the chunk.</param>
     private void OnChunkReceived(Packet.Packet packet) {

--- a/SSMP/Networking/Client/ClientUpdateManager.cs
+++ b/SSMP/Networking/Client/ClientUpdateManager.cs
@@ -58,23 +58,21 @@ internal class ClientUpdateManager : UpdateManager<ServerUpdatePacket, ServerUpd
     }
 
     /// <summary>
-    /// Set slice data in the current packet.
+    /// Send a slice packet immediately, bypassing the gameplay tick loop.
     /// </summary>
     /// <param name="chunkId">The ID of the chunk the slice belongs to.</param>
     /// <param name="sliceId">The ID of the slice within the chunk.</param>
     /// <param name="numSlices">The number of slices in the chunk.</param>
     /// <param name="data">The raw data in the slice as a byte array.</param>
-    public void SetSliceData(byte chunkId, byte sliceId, byte numSlices, byte[] data) {
-        var sliceData = new SliceData {
+    public void SetSliceData(byte chunkId, ushort sliceId, ushort numSlices, byte[] data) {
+        var slicePacket = new ServerUpdatePacket();
+        slicePacket.SetSendingPacketData(ServerUpdatePacketId.Slice, new SliceData {
             ChunkId = chunkId,
             SliceId = sliceId,
             NumSlices = numSlices,
             Data = data
-        };
-
-        lock (Lock) {
-            CurrentUpdatePacket.SetSendingPacketData(ServerUpdatePacketId.Slice, sliceData);
-        }
+        });
+        SendSlicePacket(slicePacket);
     }
 
     /// <summary>

--- a/SSMP/Networking/Client/NetClient.cs
+++ b/SSMP/Networking/Client/NetClient.cs
@@ -223,14 +223,12 @@ internal class NetClient : INetClient {
     /// before immediately starting a new one.</param>
     private void InternalDisconnect(bool shouldFireEvent = true) {
         IEncryptedTransport? transportToDisconnect;
-        bool wasConnectedOrConnecting;
 
         lock (_connectionLock) {
             if (ConnectionStatus == ClientConnectionStatus.NotConnected) {
                 return;
             }
 
-            wasConnectedOrConnecting = true;
             ConnectionStatus = ClientConnectionStatus.NotConnected;
             transportToDisconnect = _transport;
             _transport = null;
@@ -258,7 +256,7 @@ internal class NetClient : INetClient {
 
         // Fire DisconnectEvent on main thread for all disconnects (internal or explicit)
         // This provides a consistent notification for observers to clean up resources
-        if (shouldFireEvent && wasConnectedOrConnecting) {
+        if (shouldFireEvent) {
             ThreadUtil.RunActionOnMainThread(() => {
                     try {
                         DisconnectEvent?.Invoke();
@@ -390,11 +388,26 @@ internal class NetClient : INetClient {
         ThreadUtil.RunActionOnMainThread(() => { ConnectFailedEvent?.Invoke(result); });
     }
 
+    /// <summary>
+    /// Configures chunk handling for the pre-authentication phase.
+    /// </summary>
+    /// <remarks>
+    /// Before the server accepts the connection, the client only allows small chunks
+    /// required for the connection handshake. Addon chunk traffic is disabled because
+    /// addon packet IDs are not valid until authentication succeeds.
+    /// </remarks>
     private void EnterPreAuthChunkMode() {
         _chunkReceiver.MaxAllowedChunkSize = ConnectionManager.MaxPreAuthChunkSize;
         _connectionManager.AllowAddonChunks = false;
     }
 
+    /// <summary>
+    /// Configures chunk handling for the post-authentication phase.
+    /// </summary>
+    /// <remarks>
+    /// After the server accepts the connection, normal chunk limits are restored and
+    /// addon chunk traffic is enabled because addon packet IDs have been assigned.
+    /// </remarks>
     private void EnterPostAuthChunkMode() {
         _chunkReceiver.MaxAllowedChunkSize = ConnectionManager.MaxChunkSize;
         _connectionManager.AllowAddonChunks = true;

--- a/SSMP/Networking/Client/NetClient.cs
+++ b/SSMP/Networking/Client/NetClient.cs
@@ -102,7 +102,9 @@ internal class NetClient : INetClient {
         // Create chunk sender/receiver with delegates to the update manager
         _chunkSender = new ChunkSender(UpdateManager.SetSliceData);
         _chunkReceiver = new ChunkReceiver(UpdateManager.SetSliceAckData);
+        UpdateManager.EnqueueChunkPacketAction = _chunkSender.EnqueuePacket;
         _connectionManager = new ClientConnectionManager(_packetManager, _chunkSender, _chunkReceiver);
+        EnterPreAuthChunkMode();
 
         _connectionManager.ServerInfoReceivedEvent += OnServerInfoReceived;
     }
@@ -124,20 +126,37 @@ internal class NetClient : INetClient {
         List<AddonData> addonData,
         IEncryptedTransport transport
     ) {
+        var disconnectExisting = false;
+
         // Prevent multiple simultaneous connection attempts
         lock (_connectionLock) {
-            if (ConnectionStatus == ClientConnectionStatus.Connecting) {
-                Logger.Warn("Connection attempt already in progress, ignoring duplicate request");
-                return;
+            switch (ConnectionStatus) {
+                case ClientConnectionStatus.Connecting:
+                    Logger.Warn("Connection attempt already in progress, ignoring duplicate request");
+                    return;
+                case ClientConnectionStatus.Connected:
+                    disconnectExisting = true;
+                    break;
+                case ClientConnectionStatus.NotConnected:
+                    break;
+                default:
+                    ConnectionStatus = ClientConnectionStatus.Connecting;
+                    break;
             }
+        }
 
-            if (ConnectionStatus == ClientConnectionStatus.Connected) {
-                Logger.Warn("Already connected, disconnecting first");
-                // Don't fire DisconnectEvent when transitioning to a new connection
-                InternalDisconnect(shouldFireEvent: false);
+        if (disconnectExisting) {
+            Logger.Warn("Already connected, disconnecting first");
+            InternalDisconnect(shouldFireEvent: false);
+
+            lock (_connectionLock) {
+                if (ConnectionStatus == ClientConnectionStatus.Connecting) {
+                    Logger.Warn("Connection attempt already in progress, ignoring duplicate request");
+                    return;
+                }
+
+                ConnectionStatus = ClientConnectionStatus.Connecting;
             }
-
-            ConnectionStatus = ClientConnectionStatus.Connecting;
         }
 
         // Start a new thread for establishing the connection, otherwise Unity will hang
@@ -147,15 +166,25 @@ internal class NetClient : INetClient {
                     _transport.DataReceivedEvent += OnReceiveData;
                     _transport.Connect(address, port);
 
-                    UpdateManager.Transport = _transport;
-                    UpdateManager.Reset();
-                    UpdateManager.StartUpdates();
-                    _chunkSender.Start();
+                    lock (_connectionLock) {
+                        if (ConnectionStatus != ClientConnectionStatus.Connecting) {
+                            // Connection attempt was aborted (disconnected or disposed)
+                            _transport.DataReceivedEvent -= OnReceiveData;
+                            _transport.Disconnect();
+                            return;
+                        }
 
-                    // Subscribes all connection methods to timeout events
-                    UpdateManager.TimeoutEvent += OnConnectTimedOut;
+                        UpdateManager.Transport = _transport;
+                        UpdateManager.Reset();
+                        UpdateManager.StartUpdates();
+                        _chunkSender.Start();
+                        EnterPreAuthChunkMode();
 
-                    _connectionManager.StartConnection(username, authKey, addonData);
+                        // Subscribes all connection methods to timeout events
+                        UpdateManager.TimeoutEvent += OnConnectTimedOut;
+
+                        _connectionManager.StartConnection(username, authKey, addonData);
+                    }
                 } catch (TlsTimeoutException) {
                     Logger.Info("DTLS connection timed out");
                     HandleConnectFailed(new ConnectionFailedResult { Reason = ConnectionFailedReason.TimedOut });
@@ -177,23 +206,37 @@ internal class NetClient : INetClient {
     /// <summary>
     /// Disconnect from the current server.
     /// </summary>
-    public void Disconnect() {
-        lock (_connectionLock) {
-            InternalDisconnect();
-        }
+    public void Disconnect() => InternalDisconnect();
+
+    /// <summary>
+    /// Dispose of the network client and its owned disposable resources.
+    /// </summary>
+    public void Dispose() {
+        InternalDisconnect(shouldFireEvent: false);
+        _chunkSender.Dispose();
     }
 
     /// <summary>
-    /// Internal disconnect implementation without locking (assumes caller holds lock).
+    /// Internal disconnect implementation that transitions the connection state first and performs blocking teardown
+    /// outside the connection lock.
     /// </summary>
     /// <param name="shouldFireEvent">Whether to fire DisconnectEvent. Set to false when cleaning up an old connection
     /// before immediately starting a new one.</param>
     private void InternalDisconnect(bool shouldFireEvent = true) {
-        if (ConnectionStatus == ClientConnectionStatus.NotConnected) {
-            return;
-        }
+        IEncryptedTransport? transportToDisconnect;
+        bool wasConnectedOrConnecting;
 
-        var wasConnectedOrConnecting = ConnectionStatus != ClientConnectionStatus.NotConnected;
+        lock (_connectionLock) {
+            if (ConnectionStatus == ClientConnectionStatus.NotConnected) {
+                return;
+            }
+
+            wasConnectedOrConnecting = true;
+            ConnectionStatus = ClientConnectionStatus.NotConnected;
+            transportToDisconnect = _transport;
+            _transport = null;
+            _leftoverData = null;
+        }
 
         try {
             UpdateManager.StopUpdates();
@@ -201,22 +244,18 @@ internal class NetClient : INetClient {
             UpdateManager.TimeoutEvent -= OnUpdateTimedOut;
             _chunkSender.Stop();
             _chunkReceiver.Reset();
+            EnterPreAuthChunkMode();
 
-            if (_transport != null) {
-                _transport.DataReceivedEvent -= OnReceiveData;
-                _transport.Disconnect();
+            if (transportToDisconnect != null) {
+                transportToDisconnect.DataReceivedEvent -= OnReceiveData;
+                transportToDisconnect.Disconnect();
             }
         } catch (Exception e) {
             Logger.Error($"Error in NetClient.InternalDisconnect: {e}");
         }
 
-        ConnectionStatus = ClientConnectionStatus.NotConnected;
-
         // Clear all client addon packet handlers, because their IDs become invalid
         _packetManager.ClearClientAddonUpdatePacketHandlers();
-
-        // Clear leftover data
-        _leftoverData = null;
 
         // Fire DisconnectEvent on main thread for all disconnects (internal or explicit)
         // This provides a consistent notification for observers to clean up resources
@@ -258,7 +297,7 @@ internal class NetClient : INetClient {
                 // Route all transports through UpdateManager for sequence/ACK tracking
                 // UpdateManager will skip UDP-specific logic for Steam transports
                 UpdateManager.OnReceivePacket<ClientUpdatePacket, ClientUpdatePacketId>(clientUpdatePacket);
-                
+
                 // First check for slice or slice ack data and handle it separately by passing it onto either the chunk 
                 // sender or chunk receiver
                 var packetData = clientUpdatePacket.GetPacketData();
@@ -294,6 +333,8 @@ internal class NetClient : INetClient {
                 ConnectionStatus = ClientConnectionStatus.Connected;
             }
 
+            EnterPostAuthChunkMode();
+
             ThreadUtil.RunActionOnMainThread(() => {
                     try {
                         ConnectEvent?.Invoke(serverInfo);
@@ -306,12 +347,12 @@ internal class NetClient : INetClient {
         }
 
         // Connection rejected
-        var result = serverInfo.ConnectionResult == ServerConnectionResult.InvalidAddons
+        ConnectionFailedResult result = serverInfo.ConnectionResult == ServerConnectionResult.InvalidAddons
             ? new ConnectionInvalidAddonsResult {
                 Reason = ConnectionFailedReason.InvalidAddons,
                 AddonData = serverInfo.AddonData
             }
-            : (ConnectionFailedResult) new ConnectionFailedMessageResult {
+            : new ConnectionFailedMessageResult {
                 Reason = ConnectionFailedReason.Other,
                 Message = serverInfo.ConnectionRejectedMessage
             };
@@ -341,10 +382,23 @@ internal class NetClient : INetClient {
     /// <param name="result">The connection failed result containing failure details.</param>
     private void HandleConnectFailed(ConnectionFailedResult result) {
         lock (_connectionLock) {
-            InternalDisconnect();
+            if (ConnectionStatus != ClientConnectionStatus.Connecting) {
+                return;
+            }
         }
 
+        InternalDisconnect();
         ThreadUtil.RunActionOnMainThread(() => { ConnectFailedEvent?.Invoke(result); });
+    }
+
+    private void EnterPreAuthChunkMode() {
+        _chunkReceiver.MaxAllowedChunkSize = ConnectionManager.MaxPreAuthChunkSize;
+        _connectionManager.AllowAddonChunks = false;
+    }
+
+    private void EnterPostAuthChunkMode() {
+        _chunkReceiver.MaxAllowedChunkSize = ConnectionManager.MaxChunkSize;
+        _connectionManager.AllowAddonChunks = true;
     }
 
     /// <inheritdoc />
@@ -355,7 +409,7 @@ internal class NetClient : INetClient {
 
         // Check whether there already is a network sender for the given addon
         if (addon.NetworkSender != null) {
-            if (!(addon.NetworkSender is IClientAddonNetworkSender<TPacketId> addonNetworkSender)) {
+            if (addon.NetworkSender is not IClientAddonNetworkSender<TPacketId> addonNetworkSender) {
                 throw new InvalidOperationException(
                     "Cannot request network senders with differing generic parameters"
                 );

--- a/SSMP/Networking/Client/NetClient.cs
+++ b/SSMP/Networking/Client/NetClient.cs
@@ -138,7 +138,6 @@ internal class NetClient : INetClient {
                     disconnectExisting = true;
                     break;
                 case ClientConnectionStatus.NotConnected:
-                    break;
                 default:
                     ConnectionStatus = ClientConnectionStatus.Connecting;
                     break;

--- a/SSMP/Networking/ConnectionManager.cs
+++ b/SSMP/Networking/ConnectionManager.cs
@@ -19,12 +19,18 @@ internal abstract class ConnectionManager(PacketManager packetManager) {
     /// <summary>
     /// The maximum number of slices in a chunk.
     /// </summary>
-    public const int MaxSlicesPerChunk = 256;
+    public const int MaxSlicesPerChunk = 32768;
 
     /// <summary>
     /// The maximum size of a chunk in bytes.
     /// </summary>
     public const int MaxChunkSize = MaxSliceSize * MaxSlicesPerChunk;
+
+    /// <summary>
+    /// The maximum chunk size accepted before a connection is fully established.
+    /// Keeps handshake traffic well below the full post-auth chunk budget.
+    /// </summary>
+    public const int MaxPreAuthChunkSize = 256 * 1024;
 
     /// <summary>
     /// The number of milliseconds a connection attempt can maximally take before being timed out.

--- a/SSMP/Networking/Packet/BasePacket.cs
+++ b/SSMP/Networking/Packet/BasePacket.cs
@@ -46,6 +46,12 @@ internal abstract class BasePacket<TPacketId> where TPacketId : Enum {
     /// Whether this packet contains data that needs to be reliable.
     /// </summary>
     public bool ContainsReliableData { get; protected set; }
+    
+    /// <summary>
+    /// Gets whether this packet contains normal connection data,
+    /// without building the combined packet-data cache.
+    /// </summary>
+    public bool HasNormalData => NormalPacketData.Count > 0;
 
     /// <summary>
     /// Construct the update packet with the given raw packet instance to read from.

--- a/SSMP/Networking/Packet/BasePacket.cs
+++ b/SSMP/Networking/Packet/BasePacket.cs
@@ -46,12 +46,6 @@ internal abstract class BasePacket<TPacketId> where TPacketId : Enum {
     /// Whether this packet contains data that needs to be reliable.
     /// </summary>
     public bool ContainsReliableData { get; protected set; }
-    
-    /// <summary>
-    /// Gets whether this packet contains normal connection data,
-    /// without building the combined packet-data cache.
-    /// </summary>
-    public bool HasNormalData => NormalPacketData.Count > 0;
 
     /// <summary>
     /// Construct the update packet with the given raw packet instance to read from.

--- a/SSMP/Networking/Packet/ChunkAddonPacketBuilder.cs
+++ b/SSMP/Networking/Packet/ChunkAddonPacketBuilder.cs
@@ -1,0 +1,94 @@
+using System;
+using SSMP.Networking.Packet.Connection;
+using SSMP.Networking.Packet.Data;
+
+namespace SSMP.Networking.Packet;
+
+/// <summary>
+/// Builds the connection-packet envelopes used for large chunked addon payloads.
+/// </summary>
+internal static class ChunkAddonPacketBuilder {
+    /// <summary>
+    /// Build a chunked addon payload destined for a client.
+    /// </summary>
+    public static Packet BuildClientBound(byte packetId, byte addonId, IPacketData packetData) {
+        return BuildPacket(
+            new ClientConnectionPacket(),
+            ClientConnectionPacketId.ChunkAddonData,
+            packetId,
+            addonId,
+            packetData
+        );
+    }
+
+    /// <summary>
+    /// Build a chunked addon payload destined for the server.
+    /// </summary>
+    public static Packet BuildServerBound(byte packetId, byte addonId, IPacketData packetData) {
+        return BuildPacket(
+            new ServerConnectionPacket(),
+            ServerConnectionPacketId.ChunkAddonData,
+            packetId,
+            addonId,
+            packetData
+        );
+    }
+
+    /// <summary>
+    /// Build a chunk-transport connection packet that wraps addon payload data in a
+    /// <see cref="ChunkAddonData"/> envelope.
+    /// </summary>
+    /// <param name="connectionPacket">
+    /// The outer connection packet instance used to serialize the chunk addon envelope.
+    /// </param>
+    /// <param name="chunkAddonPacketId">
+    /// The connection-packet ID that identifies the payload as <see cref="ChunkAddonData"/>.
+    /// </param>
+    /// <param name="packetId">The addon-local packet ID to embed in the envelope.</param>
+    /// <param name="addonId">The addon ID that owns the packet payload.</param>
+    /// <param name="packetData">The addon payload to serialize and wrap.</param>
+    /// <returns>
+    /// A serialized packet ready for chunk transport, guaranteed to be larger than
+    /// <see cref="ushort.MaxValue"/> and no larger than <see cref="ConnectionManager.MaxChunkSize"/>.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the serialized packet exceeds <see cref="ConnectionManager.MaxChunkSize"/> or when
+    /// the payload is small enough to fit in the standard non-chunk addon transport.
+    /// </exception>
+    private static Packet BuildPacket<TPacketId>(
+        BasePacket<TPacketId> connectionPacket,
+        TPacketId chunkAddonPacketId,
+        byte packetId,
+        byte addonId,
+        IPacketData packetData
+    ) where TPacketId : Enum {
+        // TODO: Revisit this path in a dedicated feature branch and remove the intermediate payload array copy.
+        var payloadPacket = new Packet();
+        packetData.WriteData(payloadPacket);
+
+        connectionPacket.SetSendingPacketData(
+            chunkAddonPacketId,
+            new ChunkAddonData {
+                AddonId = addonId,
+                PacketId = packetId,
+                Payload = payloadPacket.ToArray()
+            }
+        );
+
+        var packet = new Packet();
+        connectionPacket.CreatePacket(packet);
+
+        return packet.Length switch {
+            > ConnectionManager.MaxChunkSize => throw new ArgumentException(
+                $"Addon packet data size ({packet.Length} bytes) exceeds the maximum chunk size ({ConnectionManager.MaxChunkSize} bytes).",
+                nameof(packetData)
+            ),
+            <= ushort.MaxValue => throw new ArgumentException(
+                $"Addon packet data size ({packet.Length} bytes) is not larger than ushort.MaxValue ({ushort.MaxValue}). " +
+                "For payloads smaller than or equal to ushort.MaxValue, please use standard updates instead of chunk transport.",
+                nameof(packetData)
+            ),
+            _ => packet
+        };
+    }
+}

--- a/SSMP/Networking/Packet/Connection/ClientConnectionPacket.cs
+++ b/SSMP/Networking/Packet/Connection/ClientConnectionPacket.cs
@@ -8,11 +8,10 @@ namespace SSMP.Networking.Packet.Connection;
 internal class ClientConnectionPacket : BasePacket<ClientConnectionPacketId> {
     /// <inheritdoc />
     protected override IPacketData InstantiatePacketDataFromId(ClientConnectionPacketId packetId) {
-        switch (packetId) {
-            case ClientConnectionPacketId.ServerInfo:
-                return new ServerInfo();
-            default:
-                return new EmptyData();
-        }
+        return packetId switch {
+            ClientConnectionPacketId.ServerInfo => new ServerInfo(),
+            ClientConnectionPacketId.ChunkAddonData => new ChunkAddonData(),
+            _ => new EmptyData()
+        };
     }
 }

--- a/SSMP/Networking/Packet/Connection/ClientConnectionPacketId.cs
+++ b/SSMP/Networking/Packet/Connection/ClientConnectionPacketId.cs
@@ -8,4 +8,9 @@ internal enum ClientConnectionPacketId {
     /// Information about the server meant for the client detailing whether the connection was accepted.
     /// </summary>
     ServerInfo = 0,
+
+    /// <summary>
+    /// Chunk-only large addon payload sent over the connection chunk path.
+    /// </summary>
+    ChunkAddonData = 1,
 }

--- a/SSMP/Networking/Packet/Connection/ClientConnectionPacketId.cs
+++ b/SSMP/Networking/Packet/Connection/ClientConnectionPacketId.cs
@@ -1,8 +1,12 @@
 namespace SSMP.Networking.Packet.Connection;
 
 /// <summary>
-/// Enumeration of packet IDs for connection packet for server to client communication.
+/// Enumeration of packet IDs for connection-phase packets for server-to-client communication.
 /// </summary>
+/// <remarks>
+/// These packets are used for handshake traffic and, by deliberate design choice,
+/// for chunked addon payload transport.
+/// </remarks>
 internal enum ClientConnectionPacketId {
     /// <summary>
     /// Information about the server meant for the client detailing whether the connection was accepted.

--- a/SSMP/Networking/Packet/Connection/ServerConnectionPacket.cs
+++ b/SSMP/Networking/Packet/Connection/ServerConnectionPacket.cs
@@ -8,11 +8,10 @@ namespace SSMP.Networking.Packet.Connection;
 internal class ServerConnectionPacket : BasePacket<ServerConnectionPacketId> {
     /// <inheritdoc />
     protected override IPacketData InstantiatePacketDataFromId(ServerConnectionPacketId packetId) {
-        switch (packetId) {
-            case ServerConnectionPacketId.ClientInfo:
-                return new ClientInfo();
-            default:
-                return new EmptyData();
-        }
+        return packetId switch {
+            ServerConnectionPacketId.ClientInfo => new ClientInfo(),
+            ServerConnectionPacketId.ChunkAddonData => new ChunkAddonData(),
+            _ => new EmptyData()
+        };
     }
 }

--- a/SSMP/Networking/Packet/Connection/ServerConnectionPacketId.cs
+++ b/SSMP/Networking/Packet/Connection/ServerConnectionPacketId.cs
@@ -8,4 +8,9 @@ internal enum ServerConnectionPacketId {
     /// Information about the client that the server can use to determine whether to accept the connection.
     /// </summary>
     ClientInfo = 0,
+
+    /// <summary>
+    /// Chunk-only large addon payload sent over the connection chunk path.
+    /// </summary>
+    ChunkAddonData = 1,
 }

--- a/SSMP/Networking/Packet/Connection/ServerConnectionPacketId.cs
+++ b/SSMP/Networking/Packet/Connection/ServerConnectionPacketId.cs
@@ -1,8 +1,12 @@
 namespace SSMP.Networking.Packet.Connection;
 
 /// <summary>
-/// Enumeration of packet IDs for the connection packet for client to server communication.
+/// Enumeration of packet IDs for connection-phase packets for client-to-server communication.
 /// </summary>
+/// <remarks>
+/// These packets are used for handshake traffic and, by deliberate design choice,
+/// for chunked addon payload transport.
+/// </remarks>
 internal enum ServerConnectionPacketId {
     /// <summary>
     /// Information about the client that the server can use to determine whether to accept the connection.

--- a/SSMP/Networking/Packet/Data/ChunkAddonData.cs
+++ b/SSMP/Networking/Packet/Data/ChunkAddonData.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace SSMP.Networking.Packet.Data;
+
+/// <summary>
+/// Dedicated chunk-only envelope for large addon payloads.
+/// This bypasses the normal BasePacket addon framing so it can carry payloads above ushort.MaxValue.
+/// </summary>
+internal sealed class ChunkAddonData : IPacketData {
+    /// <inheritdoc />
+    public bool IsReliable => true;
+
+    /// <inheritdoc />
+    public bool DropReliableDataIfNewerExists => false;
+
+    /// <summary>
+    /// The addon ID that owns the payload.
+    /// </summary>
+    public byte AddonId { get; set; }
+
+    /// <summary>
+    /// The addon-local packet ID of the payload.
+    /// </summary>
+    public byte PacketId { get; set; }
+
+    /// <summary>
+    /// The serialized addon payload bytes.
+    /// </summary>
+    public byte[] Payload { get; set; } = null!;
+
+    /// <inheritdoc />
+    public void WriteData(IPacket packet) {
+        packet.Write(AddonId);
+        packet.Write(PacketId);
+        packet.Write(Payload.Length);
+        packet.Write(Payload);
+    }
+
+    /// <inheritdoc />
+    public void ReadData(IPacket packet) {
+        AddonId = packet.ReadByte();
+        PacketId = packet.ReadByte();
+
+        var payloadLength = packet.ReadInt();
+        if (payloadLength < 0) {
+            throw new Exception($"Chunk addon payload length cannot be negative: {payloadLength}");
+        }
+
+        Payload = packet.ReadBytes(payloadLength);
+    }
+}

--- a/SSMP/Networking/Packet/Data/SliceAckData.cs
+++ b/SSMP/Networking/Packet/Data/SliceAckData.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SSMP.Networking.Packet.Data;
 
 /// <summary>
@@ -9,15 +11,14 @@ internal class SliceAckData : IPacketData {
 
     /// <inheritdoc />
     public bool DropReliableDataIfNewerExists => false;
-    
+
     /// <summary>
     /// The ID of the chunk that is being networked.
     /// </summary>
     public byte ChunkId { get; set; }
 
     /// <summary>
-    /// The total number of slices in this chunk. Encoded as a byte where all values are shifted by -1 to ensure we
-    /// can encode 256 as a value, since we don't use 0.
+    /// The total number of slices in this chunk.
     /// </summary>
     public ushort NumSlices { get; set; }
 
@@ -31,38 +32,39 @@ internal class SliceAckData : IPacketData {
     /// <inheritdoc />
     public void WriteData(IPacket packet) {
         packet.Write(ChunkId);
-
-        var encodedNumSlices = (byte) (NumSlices - 1);
-        packet.Write(encodedNumSlices);
+        packet.Write(NumSlices);
 
         // Keep track of current index for writing ack array
         var currentIndex = 0;
-        // Do while loop, since we will always be writing at least a single byte bit flag
-        do {
+        while (currentIndex < NumSlices) {
             packet.Write(CreateAckFlag(currentIndex, currentIndex + 8, Acked));
-            // Continue while loop if we need to write another flag, namely when the new starting index is smaller
-            // than the number of slices
-        } while ((currentIndex += 8) <= NumSlices);
+            currentIndex += 8;
+        }
     }
 
     /// <inheritdoc />
     public void ReadData(IPacket packet) {
         ChunkId = packet.ReadByte();
+        NumSlices = packet.ReadUShort();
 
-        var encodedNumSlices = packet.ReadByte();
-        NumSlices = (ushort) (encodedNumSlices + 1);
+        switch (NumSlices) {
+            case < 1:
+                throw new Exception("Invalid slice count: NumSlices must be at least 1");
+            case > ConnectionManager.MaxSlicesPerChunk:
+                throw new Exception(
+                    $"Invalid slice count: {NumSlices} exceeds maximum of {ConnectionManager.MaxSlicesPerChunk}"
+                );
+        }
 
-        var acked = new bool[ConnectionManager.MaxSlicesPerChunk];
+        var acked = new bool[NumSlices];
 
         // Keep track of current index for writing to ack array
         var currentIndex = 0;
-        // Do while loop, since we will always be reading at least one byte for the bit flag
-        do {
+        while (currentIndex < NumSlices) {
             var flag = packet.ReadByte();
             ReadAckFlag(flag, currentIndex, currentIndex + 8, ref acked);
-            // Continue while loop if we need to read another flag, namely when the new starting index is smaller
-            // than the number of slices
-        } while ((currentIndex += 8) <= NumSlices);
+            currentIndex += 8;
+        }
 
         Acked = acked;
     }
@@ -82,7 +84,7 @@ internal class SliceAckData : IPacketData {
             if (acked.Length <= i) {
                 break;
             }
-            
+
             if (acked[i]) {
                 flag |= currentValue;
             }
@@ -104,6 +106,10 @@ internal class SliceAckData : IPacketData {
         byte currentValue = 1;
 
         for (var i = startIndex; i < endIndex; i++) {
+            if (i >= acked.Length) {
+                break;
+            }
+
             if ((flag & currentValue) != 0) {
                 acked[i] = true;
             }

--- a/SSMP/Networking/Packet/Data/SliceData.cs
+++ b/SSMP/Networking/Packet/Data/SliceData.cs
@@ -69,8 +69,10 @@ internal class SliceData : IPacketData {
         ushort length;
         if (SliceId == NumSlices - 1) {
             length = packet.ReadUShort();
-            if (length < 1 || length > ConnectionManager.MaxSliceSize) {
-                throw new Exception($"Invalid slice data length: {length} must be between 1 and {ConnectionManager.MaxSliceSize}");
+            if (length is < 1 or > ConnectionManager.MaxSliceSize) {
+                throw new Exception(
+                    $"Invalid slice data length: {length} must be between 1 and {ConnectionManager.MaxSliceSize}"
+                );
             }
         } else {
             length = ConnectionManager.MaxSliceSize;

--- a/SSMP/Networking/Packet/Data/SliceData.cs
+++ b/SSMP/Networking/Packet/Data/SliceData.cs
@@ -11,7 +11,7 @@ internal class SliceData : IPacketData {
 
     /// <inheritdoc />
     public bool DropReliableDataIfNewerExists => false;
-    
+
     /// <summary>
     /// The ID of the chunk that is being networked.
     /// </summary>
@@ -20,11 +20,10 @@ internal class SliceData : IPacketData {
     /// <summary>
     /// The ID of this slice.
     /// </summary>
-    public byte SliceId { get; set; }
+    public ushort SliceId { get; set; }
 
     /// <summary>
-    /// The total number of slices in this chunk. It is an unsigned short because we can have 256 slices in a chunk.
-    /// It is encoded as a byte, where all values are shifted by one since 0 is not used.
+    /// The total number of slices in this chunk.
     /// </summary>
     public ushort NumSlices { get; set; }
 
@@ -37,44 +36,46 @@ internal class SliceData : IPacketData {
     public void WriteData(IPacket packet) {
         packet.Write(ChunkId);
         packet.Write(SliceId);
-
-        // Shift all values by -1 so that we can encode 256 as a number of slices
-        var encodedNumSlices = (byte) (NumSlices - 1);
-        packet.Write(encodedNumSlices);
+        packet.Write(NumSlices);
 
         var length = Data.Length;
         if (length > ConnectionManager.MaxSliceSize) {
-            throw new ArgumentOutOfRangeException(nameof(Data), "Length of data for slice cannot exceed 1024");
+            throw new ArgumentOutOfRangeException(
+                nameof(Data), $"Length of data for slice cannot exceed {ConnectionManager.MaxSliceSize}"
+            );
         }
 
         if (SliceId == NumSlices - 1) {
             packet.Write((ushort) length);
         }
 
-        for (var i = 0; i < length; i++) {
-            packet.Write(Data[i]);
-        }
+        packet.Write(Data);
     }
 
     /// <inheritdoc />
     public void ReadData(IPacket packet) {
         ChunkId = packet.ReadByte();
-        SliceId = packet.ReadByte();
+        SliceId = packet.ReadUShort();
+        NumSlices = packet.ReadUShort();
 
-        // Read the encoded byte and shift it by 1 again
-        var encodedNumSlices = packet.ReadByte();
-        NumSlices = (ushort) (encodedNumSlices + 1);
+        if (NumSlices is < 1 or > ConnectionManager.MaxSlicesPerChunk) {
+            throw new Exception($"Invalid slice count: {NumSlices}");
+        }
+
+        if (SliceId >= NumSlices) {
+            throw new Exception($"SliceId {SliceId} exceeds total slices {NumSlices}");
+        }
 
         ushort length;
         if (SliceId == NumSlices - 1) {
             length = packet.ReadUShort();
+            if (length < 1 || length > ConnectionManager.MaxSliceSize) {
+                throw new Exception($"Invalid slice data length: {length} must be between 1 and {ConnectionManager.MaxSliceSize}");
+            }
         } else {
             length = ConnectionManager.MaxSliceSize;
         }
 
-        Data = new byte[length];
-        for (var i = 0; i < length; i++) {
-            Data[i] = packet.ReadByte();
-        }
+        Data = packet.ReadBytes(length);
     }
 }

--- a/SSMP/Networking/Packet/IPacket.cs
+++ b/SSMP/Networking/Packet/IPacket.cs
@@ -113,6 +113,12 @@ public interface IPacket {
     /// <typeparam name="TEnum">The enum type that the set also uses.</typeparam>
     void WriteBitFlag<TEnum>(ISet<TEnum> set) where TEnum : Enum;
 
+    /// <summary>
+    /// Write an array of bytes to the packet.
+    /// </summary>
+    /// <param name="values">A byte array of values to write.</param>
+    void Write(byte[] values);
+
     #endregion
 
     #region Reading integral numeric types
@@ -217,6 +223,13 @@ public interface IPacket {
     /// <returns>The set containing the enum values where the corresponding bit in the flag was set to 1.</returns>
     /// <typeparam name="TEnum">The enum type that the set also uses.</typeparam>
     ISet<TEnum> ReadBitFlag<TEnum>() where TEnum : Enum;
+
+    /// <summary>
+    /// Read an array of bytes of the given length from the packet.
+    /// </summary>
+    /// <param name="length">The length to read.</param>
+    /// <returns>A byte array of the given length containing the content at the current position in the packet.</returns>
+    byte[] ReadBytes(int length);
 
     #endregion
 }

--- a/SSMP/Networking/Packet/LengthCountingPacket.cs
+++ b/SSMP/Networking/Packet/LengthCountingPacket.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using SSMP.Math;
+
+namespace SSMP.Networking.Packet;
+
+/// <summary>
+/// A lightweight implementation of IPacket that only counts the number of bytes written,
+/// completely avoiding any heap allocations or byte copies during size validation.
+/// </summary>
+public sealed class LengthCountingPacket : IPacket {
+    /// <summary>
+    /// Gets the number of bytes counted.
+    /// </summary>
+    public int Length { get; private set; }
+
+    /// <summary>
+    /// Resets the byte count back to zero.
+    /// </summary>
+    public void Reset() => Length = 0;
+
+    /// <inheritdoc />
+    public void Write(byte value) => Length += 1;
+
+    /// <inheritdoc />
+    public void Write(ushort value) => Length += 2;
+
+    /// <inheritdoc />
+    public void Write(uint value) => Length += 4;
+
+    /// <inheritdoc />
+    public void Write(ulong value) => Length += 8;
+
+    /// <inheritdoc />
+    public void Write(sbyte value) => Length += 1;
+
+    /// <inheritdoc />
+    public void Write(short value) => Length += 2;
+
+    /// <inheritdoc />
+    public void Write(int value) => Length += 4;
+
+    /// <inheritdoc />
+    public void Write(long value) => Length += 8;
+
+    /// <inheritdoc />
+    public void Write(float value) => Length += 4;
+
+    /// <inheritdoc />
+    public void Write(double value) => Length += 8;
+
+    /// <inheritdoc />
+    public void Write(bool value) => Length += 1;
+
+    /// <inheritdoc />
+    public void Write(string value) => Length += 2 + System.Text.Encoding.UTF8.GetByteCount(value);
+
+    /// <inheritdoc />
+    public void Write(Vector2 value) => Length += 8;
+
+    /// <inheritdoc />
+    public void Write(Vector3 value) => Length += 12;
+
+    /// <inheritdoc />
+    public void Write(byte[] values) => Length += values.Length;
+
+    /// <inheritdoc />
+    public void WriteBitFlag<TEnum>(ISet<TEnum> set) where TEnum : Enum {
+        var enumLength = Enum.GetValues(typeof(TEnum)).Length;
+        switch (enumLength) {
+            case <= 8:
+                Length += 1;
+                break;
+            case <= 16:
+                Length += 2;
+                break;
+            case <= 32:
+                Length += 4;
+                break;
+            case <= 64:
+                Length += 8;
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public byte ReadByte() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public ushort ReadUShort() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public uint ReadUInt() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public ulong ReadULong() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public sbyte ReadSByte() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public short ReadShort() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public int ReadInt() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public long ReadLong() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public float ReadFloat() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public double ReadDouble() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public bool ReadBool() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public string ReadString() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public Vector2 ReadVector2() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public Vector3 ReadVector3() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public ISet<TEnum> ReadBitFlag<TEnum>() where TEnum : Enum => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public byte[] ReadBytes(int length) => throw new NotSupportedException();
+}

--- a/SSMP/Networking/Packet/Packet.cs
+++ b/SSMP/Networking/Packet/Packet.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using SSMP.Math;
 
 namespace SSMP.Networking.Packet;
@@ -37,6 +38,12 @@ internal class Packet : IPacket {
     /// The length of the packet content.
     /// </summary>
     public int Length { get; private set; }
+
+    /// <summary>
+    /// Thread-local length counting packet for zero-allocation size validation.
+    /// </summary>
+    private static readonly ThreadLocal<LengthCountingPacket> LengthCountingPacket =
+        new(() => new LengthCountingPacket());
 
     /// <summary>
     /// Creates a packet with the given byte array of data.
@@ -83,6 +90,11 @@ internal class Packet : IPacket {
     /// </summary>
     public void WriteLength() {
         if (_buffer == null) throw new InvalidOperationException("Cannot write to Read-Only Packet");
+        if (_buffer.Count > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"Packet size ({_buffer.Count} bytes) exceeds the {ushort.MaxValue} bytes limit for normal updates, causing truncation. Please use the SendChunkData API instead."
+            );
+
         var length = (ushort) _buffer.Count;
         _buffer.Insert(0, (byte) length);
         _buffer.Insert(1, (byte) (length >> 8));
@@ -102,6 +114,21 @@ internal class Packet : IPacket {
     }
 
     /// <summary>
+    /// Validates that the serialized size of the given packet data does not exceed the 64 KiB (65535 bytes) limit,
+    /// throwing an InvalidOperationException if it does.
+    /// </summary>
+    /// <param name="packetData">The packet data to validate.</param>
+    public static void ValidateSize(IPacketData packetData) {
+        var counter = LengthCountingPacket.Value!;
+        counter.Reset();
+        packetData.WriteData(counter);
+        if (counter.Length > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"Addon packet data size ({counter.Length} bytes) exceeds the {ushort.MaxValue} bytes limit for normal updates. Please use the SendChunkData API instead."
+            );
+    }
+
+    /// <summary>
     /// Clears the packet buffer, allowing reuse for write-mode packets.
     /// Resets length and read position to 0.
     /// </summary>
@@ -113,9 +140,12 @@ internal class Packet : IPacket {
         if (_buffer == null) throw new InvalidOperationException("Cannot clear Read-Only Packet");
         // In write-mode, the default constructor initializes _readableBuffer to an empty array.
         // If _readableBuffer is non-empty, this packet was created from existing data and should not be cleared.
-        if (_readableBuffer.Length != 0)
-            throw new InvalidOperationException("Clear() can only be used on write-mode packets created with the default constructor.");
-            
+        if (_readableBuffer.Length != 0) {
+            throw new InvalidOperationException(
+                "Clear() can only be used on write-mode packets created with the default constructor."
+            );
+        }
+
         _buffer.Clear();
         // Readable buffer assumes it mirrors _buffer in write mode, but usually _readableBuffer is a copy or view.
         // In Write Mode (constructor Packet()), _readableBuffer is initialized to empty array.

--- a/SSMP/Networking/Packet/Packet.cs
+++ b/SSMP/Networking/Packet/Packet.cs
@@ -90,10 +90,11 @@ internal class Packet : IPacket {
     /// </summary>
     public void WriteLength() {
         if (_buffer == null) throw new InvalidOperationException("Cannot write to Read-Only Packet");
-        if (_buffer.Count > ushort.MaxValue)
+        if (_buffer.Count > ushort.MaxValue) {
             throw new InvalidOperationException(
                 $"Packet size ({_buffer.Count} bytes) exceeds the {ushort.MaxValue} bytes limit for normal updates, causing truncation. Please use the SendChunkData API instead."
             );
+        }
 
         var length = (ushort) _buffer.Count;
         _buffer.Insert(0, (byte) length);
@@ -122,10 +123,11 @@ internal class Packet : IPacket {
         var counter = LengthCountingPacket.Value!;
         counter.Reset();
         packetData.WriteData(counter);
-        if (counter.Length > ushort.MaxValue)
+        if (counter.Length > ushort.MaxValue) {
             throw new InvalidOperationException(
                 $"Addon packet data size ({counter.Length} bytes) exceeds the {ushort.MaxValue} bytes limit for normal updates. Please use the SendChunkData API instead."
             );
+        }
     }
 
     /// <summary>

--- a/SSMP/Networking/Packet/PacketManager.cs
+++ b/SSMP/Networking/Packet/PacketManager.cs
@@ -39,22 +39,26 @@ public delegate void GenericServerPacketHandler<in TPacketData>(ushort id, TPack
 /// Manages packets that are received by the given NetClient.
 /// </summary>
 internal class PacketManager {
-    
     #region Standard Packet Registries
 
     private readonly PacketHandlerRegistry<ClientUpdatePacketId, ClientPacketHandler> _clientUpdateRegistry = new(
         "client update", ClientPacketHandlerRegistryDispatcher.Instance
     );
-    private readonly PacketHandlerRegistry<ClientConnectionPacketId, ClientPacketHandler> _clientConnectionRegistry = new(
-        "client connection", ClientPacketHandlerRegistryDispatcher.Instance
-    );
+
+    private readonly PacketHandlerRegistry<ClientConnectionPacketId, ClientPacketHandler> _clientConnectionRegistry =
+        new(
+            "client connection", ClientPacketHandlerRegistryDispatcher.Instance
+        );
+
     private readonly PacketHandlerRegistry<ServerUpdatePacketId, ServerPacketHandler> _serverUpdateRegistry = new(
         "server update", ServerPacketHandlerRegistryDispatcher.Instance
     );
-    private readonly PacketHandlerRegistry<ServerConnectionPacketId, ServerPacketHandler> _serverConnectionRegistry = new(
-        "server connection", ServerPacketHandlerRegistryDispatcher.Instance
-    );
-    
+
+    private readonly PacketHandlerRegistry<ServerConnectionPacketId, ServerPacketHandler> _serverConnectionRegistry =
+        new(
+            "server connection", ServerPacketHandlerRegistryDispatcher.Instance
+        );
+
     #endregion
 
     #region Addon Packet Registries (Nested Dictionaries)
@@ -66,18 +70,20 @@ internal class PacketManager {
     // This preserves the (addonId, packetId) addressing model while reusing PacketHandlerRegistry
     // for handler management within each addon.
 
-    private readonly Dictionary<byte, PacketHandlerRegistry<byte, ClientPacketHandler>> _clientAddonUpdateRegistries = new();
+    private readonly Dictionary<byte, PacketHandlerRegistry<byte, ClientPacketHandler>> _clientAddonUpdateRegistries =
+        new();
 
     private readonly Dictionary<byte, PacketHandlerRegistry<byte, ClientPacketHandler>>
         _clientAddonConnectionRegistries = new();
 
-    private readonly Dictionary<byte, PacketHandlerRegistry<byte, ServerPacketHandler>> _serverAddonUpdateRegistries = new();
+    private readonly Dictionary<byte, PacketHandlerRegistry<byte, ServerPacketHandler>> _serverAddonUpdateRegistries =
+        new();
 
     private readonly Dictionary<byte, PacketHandlerRegistry<byte, ServerPacketHandler>>
         _serverAddonConnectionRegistries = new();
-    
+
     #endregion
-    
+
 
     #region Packet Unpacking Helper
 
@@ -155,7 +161,10 @@ internal class PacketManager {
         }
     }
 
-    private void RegisterClientConnectionPacketHandler(ClientConnectionPacketId packetId, ClientPacketHandler handler) =>
+    private void RegisterClientConnectionPacketHandler(
+        ClientConnectionPacketId packetId,
+        ClientPacketHandler handler
+    ) =>
         _clientConnectionRegistry.Register(packetId, handler);
 
     public void RegisterClientConnectionPacketHandler(ClientConnectionPacketId packetId, Action handler) =>
@@ -219,7 +228,10 @@ internal class PacketManager {
         }
     }
 
-    private void RegisterServerConnectionPacketHandler(ServerConnectionPacketId packetId, ServerPacketHandler handler) =>
+    private void RegisterServerConnectionPacketHandler(
+        ServerConnectionPacketId packetId,
+        ServerPacketHandler handler
+    ) =>
         _serverConnectionRegistry.Register(packetId, handler);
 
     public void RegisterServerConnectionPacketHandler(
@@ -259,7 +271,22 @@ internal class PacketManager {
         );
     }
 
-    private void RegisterClientAddonHandler(
+    private static void HandleClientAddonPacketSingle(
+        byte addonId,
+        byte packetId,
+        IPacketData packetData,
+        Dictionary<byte, PacketHandlerRegistry<byte, ClientPacketHandler>> registryDict,
+        string registryName
+    ) {
+        if (!registryDict.TryGetValue(addonId, out var registry)) {
+            Logger.Warn($"There is no {registryName} handler registry for addon ID {addonId}");
+            return;
+        }
+
+        registry.Execute(packetId, handler => handler(packetData));
+    }
+
+    private static void RegisterClientAddonHandler(
         byte addonId,
         byte packetId,
         ClientPacketHandler handler,
@@ -276,7 +303,7 @@ internal class PacketManager {
         registry.Register(packetId, handler);
     }
 
-    private void DeregisterClientAddonHandler(
+    private static void DeregisterClientAddonHandler(
         byte addonId,
         byte packetId,
         Dictionary<byte, PacketHandlerRegistry<byte, ClientPacketHandler>> registryDict
@@ -296,7 +323,7 @@ internal class PacketManager {
 
     #region Server Addon Helpers
 
-    private void HandleServerAddonPacket(
+    private static void HandleServerAddonPacket(
         ushort clientId,
         byte addonId,
         Dictionary<byte, IPacketData> packetDataDict,
@@ -314,7 +341,23 @@ internal class PacketManager {
         );
     }
 
-    private void RegisterServerAddonHandler(
+    private static void HandleServerAddonPacketSingle(
+        ushort clientId,
+        byte addonId,
+        byte packetId,
+        IPacketData packetData,
+        Dictionary<byte, PacketHandlerRegistry<byte, ServerPacketHandler>> registryDict,
+        string registryName
+    ) {
+        if (!registryDict.TryGetValue(addonId, out var registry)) {
+            Logger.Warn($"There is no {registryName} handler registry for addon ID {addonId}");
+            return;
+        }
+
+        registry.Execute(packetId, handler => handler(clientId, packetData));
+    }
+
+    private static void RegisterServerAddonHandler(
         byte addonId,
         byte packetId,
         ServerPacketHandler handler,
@@ -331,7 +374,7 @@ internal class PacketManager {
         registry.Register(packetId, handler);
     }
 
-    private void DeregisterServerAddonHandler(
+    private static void DeregisterServerAddonHandler(
         byte addonId,
         byte packetId,
         Dictionary<byte, PacketHandlerRegistry<byte, ServerPacketHandler>> registryDict
@@ -359,6 +402,10 @@ internal class PacketManager {
 
     public void ClearClientAddonUpdatePacketHandlers() => _clientAddonUpdateRegistries.Clear();
 
+    public void HandleClientAddonPacketSingle(byte addonId, byte packetId, IPacketData packetData) =>
+        HandleClientAddonPacketSingle(
+            addonId, packetId, packetData, _clientAddonUpdateRegistries, "client addon update"
+        );
 
     public void RegisterClientAddonConnectionPacketHandler(byte addonId, byte packetId, ClientPacketHandler handler) =>
         RegisterClientAddonHandler(addonId, packetId, handler, _clientAddonConnectionRegistries, "connection");
@@ -377,6 +424,11 @@ internal class PacketManager {
 
     public void DeregisterServerAddonUpdatePacketHandler(byte addonId, byte packetId) =>
         DeregisterServerAddonHandler(addonId, packetId, _serverAddonUpdateRegistries);
+
+    public void HandleServerAddonPacketSingle(ushort clientId, byte addonId, byte packetId, IPacketData packetData) =>
+        HandleServerAddonPacketSingle(
+            clientId, addonId, packetId, packetData, _serverAddonUpdateRegistries, "server addon update"
+        );
 
     public void RegisterServerAddonConnectionPacketHandler(byte addonId, byte packetId, ServerPacketHandler handler) =>
         RegisterServerAddonHandler(addonId, packetId, handler, _serverAddonConnectionRegistries, "connection");
@@ -434,10 +486,14 @@ internal class PacketManager {
             var packetLength = (int) packetLengthValue;
 
             // Sanity check against allocation attacks or corruption.
-            // If the length reads as invalid, we imply that protocol framing is lost (e.g. we are reading garbage as length).
-            // In this case, we cannot safely find the next packet in the stream, so we must discard the rest of the buffer.
+            // If the length reads as invalid, we imply that protocol framing is lost (e.g. we are reading garbage as
+            // length).
+            // In this case, we cannot safely find the next packet in the stream, so we must discard the rest of the
+            // buffer.
             if (packetLength == 0) {
-                Logger.Warn($"Invalid packet length read: {packetLength}. Discarding buffer to prevent processing garbage.");
+                Logger.Warn(
+                    $"Invalid packet length read: {packetLength}. Discarding buffer to prevent processing garbage."
+                );
                 break;
             }
 

--- a/SSMP/Networking/Server/NetServer.cs
+++ b/SSMP/Networking/Server/NetServer.cs
@@ -246,7 +246,7 @@ internal class NetServer : INetServer {
             ClientTimeoutEvent?.Invoke(id);
         }
 
-        client.Disconnect();
+        client.Dispose();
         _transportServer?.DisconnectClient(client.TransportClient);
         _clientsById.TryRemove(id, out _);
 
@@ -285,8 +285,8 @@ internal class NetServer : INetServer {
             client.UpdateManager.OnReceivePacket<ServerUpdatePacket, ServerUpdatePacketId>(serverUpdatePacket);
 
             var packetData = serverUpdatePacket.GetPacketData();
-            if (packetData.Remove(ServerUpdatePacketId.Slice, out var sliceData)) {
-                client.ChunkReceiver.ProcessReceivedData((SliceData) sliceData);
+            if (packetData.Remove(ServerUpdatePacketId.Slice, out var sliceDataRaw)) {
+                client.ChunkReceiver.ProcessReceivedData((SliceData) sliceDataRaw);
             }
 
             if (packetData.Remove(ServerUpdatePacketId.SliceAck, out var sliceAckData)) {
@@ -327,6 +327,8 @@ internal class NetServer : INetServer {
                     Logger.Debug("Connection has finished sending data, registering client");
 
                     client.IsRegistered = true;
+                    client.ChunkReceiver.MaxAllowedChunkSize = ConnectionManager.MaxChunkSize;
+                    client.ConnectionManager.AllowAddonChunks = true;
                     client.ConnectionManager.StopAcceptingConnection();
                 }
             );
@@ -387,6 +389,8 @@ internal class NetServer : INetServer {
         // Wait for processing thread to exit gracefully (with timeout)
         if (_processingThread is { IsAlive: true }) {
             if (!_processingThread.Join(1000)) {
+                // TODO: Stop currently falls back to best-effort teardown after the join timeout.
+                // TODO: Revisit shutdown sequencing so processing cannot observe partially torn-down state.
                 Logger.Warn("Processing thread did not exit within timeout");
             }
 
@@ -405,7 +409,7 @@ internal class NetServer : INetServer {
 
         // Clean up existing clients
         foreach (var client in _clientsById.Values) {
-            client.Disconnect();
+            client.Dispose();
         }
 
         _clientsById.Clear();
@@ -440,7 +444,7 @@ internal class NetServer : INetServer {
             return;
         }
 
-        client.Disconnect();
+        client.Dispose();
         _transportServer?.DisconnectClient(client.TransportClient);
         _clientsById.TryRemove(id, out _);
 
@@ -539,11 +543,13 @@ internal class NetServer : INetServer {
         }
 
         // After we know that this call did not use a different generic, we can update packet info
-        ServerUpdatePacket.AddonPacketInfoDict[addon.Id.Value] = new AddonPacketInfo(
+        var addonPacketInfo = new AddonPacketInfo(
             // Transform the packet instantiator function from a TPacketId as parameter to byte
             networkReceiver?.TransformPacketInstantiator(packetInstantiator)!,
             (byte) Enum.GetValues(typeof(TPacketId)).Length
         );
+        ServerUpdatePacket.AddonPacketInfoDict[addon.Id.Value] = addonPacketInfo;
+        ServerConnectionPacket.AddonPacketInfoDict[addon.Id.Value] = addonPacketInfo;
 
         return (addon.NetworkReceiver as IServerAddonNetworkReceiver<TPacketId>)!;
     }

--- a/SSMP/Networking/Server/NetServer.cs
+++ b/SSMP/Networking/Server/NetServer.cs
@@ -262,8 +262,9 @@ internal class NetServer : INetServer {
         var id = client.Id;
 
         foreach (var packet in packets) {
-            // Connection packets (ClientInfo) are handled via ChunkReceiver, not here.
-            // All packets here should be ServerUpdatePackets.
+            // Connection-phase packets are handled via ChunkReceiver, not here.
+            // That includes both ClientInfo and the deliberate reuse of connection packets for chunked addon payloads.
+            // All packets here should therefore be ServerUpdatePackets.
             var serverUpdatePacket = new ServerUpdatePacket();
             if (!serverUpdatePacket.ReadPacket(packet)) {
                 if (client.IsRegistered) {

--- a/SSMP/Networking/Server/NetServerClient.cs
+++ b/SSMP/Networking/Server/NetServerClient.cs
@@ -21,6 +21,11 @@ internal class NetServerClient : IDisposable {
     private readonly object _disposeLock = new();
 
     /// <summary>
+    /// Flag indicating whether this client has been disposed.
+    /// </summary>
+    private bool _isDisposed;
+
+    /// <summary>
     /// Concurrent dictionary for the set of IDs that are used. We use a dictionary because there is no
     /// standard implementation for a concurrent set.
     /// </summary>
@@ -100,11 +105,6 @@ internal class NetServerClient : IDisposable {
         ChunkReceiver.Reset();
         ConnectionManager.StopAcceptingConnection();
     }
-
-    /// <summary>
-    /// Flag indicating whether this client has been disposed.
-    /// </summary>
-    private bool _isDisposed;
 
     /// <summary>
     /// Dispose of the client and its owned disposable resources.

--- a/SSMP/Networking/Server/NetServerClient.cs
+++ b/SSMP/Networking/Server/NetServerClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using SSMP.Networking.Chunk;
 using SSMP.Networking.Packet;
@@ -8,7 +9,17 @@ namespace SSMP.Networking.Server;
 /// <summary>
 /// A client managed by the server. This is only used for communication from server to client.
 /// </summary>
-internal class NetServerClient {
+internal class NetServerClient : IDisposable {
+    /// <summary>
+    /// Lock object for atomic static ID generation.
+    /// </summary>
+    private static readonly object IdLock = new();
+
+    /// <summary>
+    /// Lock object for thread-safe disposal.
+    /// </summary>
+    private readonly object _disposeLock = new();
+
     /// <summary>
     /// Concurrent dictionary for the set of IDs that are used. We use a dictionary because there is no
     /// standard implementation for a concurrent set.
@@ -70,14 +81,17 @@ internal class NetServerClient {
         };
         // Create chunk sender/receiver with delegates to the update manager
         ChunkSender = new ChunkSender(UpdateManager.SetSliceData);
-        ChunkReceiver = new ChunkReceiver(UpdateManager.SetSliceAckData);
+        ChunkReceiver = new ChunkReceiver(UpdateManager.SetSliceAckData) {
+            MaxAllowedChunkSize = Networking.ConnectionManager.MaxPreAuthChunkSize
+        };
+        UpdateManager.EnqueueChunkPacketAction = ChunkSender.EnqueuePacket;
         ConnectionManager = new ServerConnectionManager(packetManager, ChunkSender, ChunkReceiver, Id);
     }
 
     /// <summary>
     /// Disconnect the client from the server.
     /// </summary>
-    public void Disconnect() {
+    private void Disconnect() {
         UsedIds.TryRemove(Id, out _);
 
         UpdateManager.StopUpdates();
@@ -88,12 +102,35 @@ internal class NetServerClient {
     }
 
     /// <summary>
+    /// Flag indicating whether this client has been disposed.
+    /// </summary>
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Dispose of the client and its owned disposable resources.
+    /// </summary>
+    public void Dispose() {
+        lock (_disposeLock) {
+            if (_isDisposed) {
+                return;
+            }
+
+            _isDisposed = true;
+        }
+
+        Disconnect();
+        ChunkSender.Dispose();
+    }
+
+    /// <summary>
     /// Resets the static ID counter and used IDs.
     /// Should be called when the server is stopped to ensure the next server session starts with ID 0.
     /// </summary>
     public static void ResetIds() {
-        UsedIds.Clear();
-        _lastId = 0;
+        lock (IdLock) {
+            UsedIds.Clear();
+            _lastId = 0;
+        }
     }
 
     /// <summary>
@@ -101,12 +138,14 @@ internal class NetServerClient {
     /// </summary>
     /// <returns>An unused ID.</returns>
     private static ushort GetId() {
-        ushort newId;
-        do {
-            newId = _lastId++;
-        } while (UsedIds.ContainsKey(newId));
+        lock (IdLock) {
+            ushort newId;
+            do {
+                newId = _lastId++;
+            } while (UsedIds.ContainsKey(newId));
 
-        UsedIds[newId] = 0;
-        return newId;
+            UsedIds[newId] = 0;
+            return newId;
+        }
     }
 }

--- a/SSMP/Networking/Server/ServerConnectionManager.cs
+++ b/SSMP/Networking/Server/ServerConnectionManager.cs
@@ -9,8 +9,12 @@ using SSMP.Networking.Packet.Data;
 namespace SSMP.Networking.Server;
 
 /// <summary>
-/// Server-side manager for handling the initial connection to a new client.
+/// Server-side manager for handling connection-phase traffic for a client.
 /// </summary>
+/// <remarks>
+/// Also handles chunked addon payloads after registration. We deliberately reused the
+/// existing connection-packet chunking path instead of adding a separate bulk-transfer path.
+/// </remarks>
 internal class ServerConnectionManager : ConnectionManager {
     /// <summary>
     /// Server-side chunk sender used to handle sending chunks.
@@ -43,7 +47,7 @@ internal class ServerConnectionManager : ConnectionManager {
     public event Action? ConnectionTimeoutEvent;
 
     /// <summary>
-    /// Whether chunked addon payloads are allowed to be dispatched.
+    /// Whether post-registration chunked addon payloads are allowed to be dispatched.
     /// </summary>
     public bool AllowAddonChunks { get; set; }
 
@@ -133,8 +137,8 @@ internal class ServerConnectionManager : ConnectionManager {
     }
 
     /// <summary>
-    /// Callback method for when a chunk is received. Will construct a connection packet and try to read the chunk
-    /// into it. If successful, will let the packet manager handle the data in it.
+    /// Callback method for when a connection-phase chunk is received.
+    /// This covers both handshake packets and the deliberate reuse of connection packets for chunked addon payloads.
     /// </summary>
     /// <param name="packet">The raw packet that contains the data from the chunk.</param>
     private void OnChunkReceived(Packet.Packet packet) {

--- a/SSMP/Networking/Server/ServerConnectionManager.cs
+++ b/SSMP/Networking/Server/ServerConnectionManager.cs
@@ -16,6 +16,7 @@ internal class ServerConnectionManager : ConnectionManager {
     /// Server-side chunk sender used to handle sending chunks.
     /// </summary>
     private readonly ChunkSender _chunkSender;
+
     /// <summary>
     /// Server-side chunk received used to receive chunks.
     /// </summary>
@@ -35,10 +36,16 @@ internal class ServerConnectionManager : ConnectionManager {
     /// Event that is called when the client has sent the client info, and thus we can check the connection request.
     /// </summary>
     public event Action<ushort, ClientInfo, ServerInfo>? ConnectionRequestEvent;
+
     /// <summary>
     /// Event that is called when the connection times out.
     /// </summary>
     public event Action? ConnectionTimeoutEvent;
+
+    /// <summary>
+    /// Whether chunked addon payloads are allowed to be dispatched.
+    /// </summary>
+    public bool AllowAddonChunks { get; set; }
 
     public ServerConnectionManager(
         PacketManager packetManager,
@@ -65,7 +72,7 @@ internal class ServerConnectionManager : ConnectionManager {
     /// </summary>
     public void StartAcceptingConnection() {
         Logger.Debug("StartAcceptingConnection");
-        
+
         _timeoutTimer.Start();
     }
 
@@ -74,7 +81,7 @@ internal class ServerConnectionManager : ConnectionManager {
     /// </summary>
     public void StopAcceptingConnection() {
         Logger.Debug("StopAcceptingConnection");
-        
+
         _timeoutTimer.Stop();
     }
 
@@ -108,7 +115,7 @@ internal class ServerConnectionManager : ConnectionManager {
         }
 
         SendServerInfo(serverInfo);
-        
+
         return serverInfo;
     }
 
@@ -137,6 +144,32 @@ internal class ServerConnectionManager : ConnectionManager {
             return;
         }
 
-        PacketManager.HandleServerConnectionPacket(_clientId, connectionPacket);
+        var packetData = connectionPacket.GetPacketData();
+        if (packetData.ContainsKey(ServerConnectionPacketId.ClientInfo)) {
+            PacketManager.HandleServerConnectionPacket(_clientId, connectionPacket);
+            return;
+        }
+
+        if (!packetData.TryGetValue(ServerConnectionPacketId.ChunkAddonData, out var chunkAddonDataRaw)) {
+            Logger.Debug($"Received unexpected connection chunk packet from client: {_clientId}");
+            return;
+        }
+
+        if (!AllowAddonChunks) {
+            Logger.Warn($"Rejected pre-registration chunked addon payload from client: {_clientId}");
+            return;
+        }
+
+        var chunkAddonData = (ChunkAddonData) chunkAddonDataRaw;
+        if (!ServerConnectionPacket.AddonPacketInfoDict.TryGetValue(chunkAddonData.AddonId, out var addonPacketInfo)) {
+            Logger.Warn($"Received chunked addon payload for unknown addon ID {chunkAddonData.AddonId}");
+            return;
+        }
+
+        var packetDataInstance = addonPacketInfo.PacketDataInstantiator.Invoke(chunkAddonData.PacketId);
+        packetDataInstance.ReadData(new Packet.Packet(chunkAddonData.Payload));
+        PacketManager.HandleServerAddonPacketSingle(
+            _clientId, chunkAddonData.AddonId, chunkAddonData.PacketId, packetDataInstance
+        );
     }
 }

--- a/SSMP/Networking/Server/ServerUpdateManager.cs
+++ b/SSMP/Networking/Server/ServerUpdateManager.cs
@@ -95,23 +95,21 @@ internal class ServerUpdateManager : UpdateManager<ClientUpdatePacket, ClientUpd
     }
 
     /// <summary>
-    /// Set slice data in the current packet.
+    /// Send a slice packet immediately, bypassing the gameplay tick loop.
     /// </summary>
     /// <param name="chunkId">The ID of the chunk the slice belongs to.</param>
     /// <param name="sliceId">The ID of the slice within the chunk.</param>
     /// <param name="numSlices">The number of slices in the chunk.</param>
     /// <param name="data">The raw data in the slice as a byte array.</param>
-    public void SetSliceData(byte chunkId, byte sliceId, byte numSlices, byte[] data) {
-        var sliceData = new SliceData {
+    public void SetSliceData(byte chunkId, ushort sliceId, ushort numSlices, byte[] data) {
+        var slicePacket = new ClientUpdatePacket();
+        slicePacket.SetSendingPacketData(ClientUpdatePacketId.Slice, new SliceData {
             ChunkId = chunkId,
             SliceId = sliceId,
             NumSlices = numSlices,
             Data = data
-        };
-
-        lock (Lock) {
-            CurrentUpdatePacket.SetSendingPacketData(ClientUpdatePacketId.Slice, sliceData);
-        }
+        });
+        SendSlicePacket(slicePacket);
     }
 
     /// <summary>

--- a/SSMP/Networking/UpdateManager.cs
+++ b/SSMP/Networking/UpdateManager.cs
@@ -114,6 +114,11 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
     protected object Lock { get; } = new();
 
     /// <summary>
+    /// Lock object for serializing all transport writes to prevent concurrent/parallel socket writes.
+    /// </summary>
+    private readonly object _transportSendLock = new();
+
+    /// <summary>
     /// Whether the transport requires application-level reliability. Protected for subclass access.
     /// </summary>
     protected bool RequiresReliability { get; private set; } = true;
@@ -183,6 +188,17 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
     public event Action? TimeoutEvent;
 
     /// <summary>
+    /// Action to enqueue a packet for chunked sending.
+    /// </summary>
+    public Action<Packet.Packet>? EnqueueChunkPacketAction { get; set; }
+
+    /// <summary>
+    /// Enqueues a packet to be sent reliably as a chunk to the destination.
+    /// </summary>
+    /// <param name="packet">The packet to send.</param>
+    public void SendChunkPacket(Packet.Packet packet) => EnqueueChunkPacketAction?.Invoke(packet);
+
+    /// <summary>
     /// Construct the update manager with a UDP socket.
     /// </summary>
     protected UpdateManager() {
@@ -216,10 +232,19 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
         _isUpdating = false;
 
         Logger.Debug("Stopping UDP updates, sending last packet");
+        // TODO: Split "flush final packet" from teardown so disconnect/shutdown does not depend on a synchronous
+        // TODO: transport write on the caller thread.
         CreateAndSendPacket();
         _cancellationTokenSource?.Cancel();
+
+        lock (Lock) {
+            Monitor.PulseAll(Lock);
+        }
+
         // Wait for thread to finish before disposing shared resources
-        _sendThread?.Join();
+        if (Thread.CurrentThread != _sendThread)
+            _sendThread?.Join();
+
         _sendThread = null;
         _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = null;
@@ -287,6 +312,8 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
             if (_requiresSequencing) {
                 CurrentUpdatePacket.Sequence = _localSequence;
                 CurrentUpdatePacket.Ack = _remoteSequence;
+                // TODO: PopulateAckField is called while Lock is already held and still re-locks internally.
+                // TODO: Flatten this re-entrant lock boundary in a dedicated concurrency cleanup pass.
                 PopulateAckField();
             }
 
@@ -301,6 +328,9 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
             // but keep the original instance for reliability data re-sending
             packetToSend = CurrentUpdatePacket;
             CurrentUpdatePacket = new TOutgoing();
+
+            // Pulse to wake up any threads waiting to set new slice data
+            Monitor.PulseAll(Lock);
         }
 
         // Track send time for RTT measurement (all transports)
@@ -433,6 +463,7 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
         if (cts == null) {
             return;
         }
+
         var token = cts.Token;
 
         // Safety constant: how many ms can we fall behind before giving up?
@@ -509,22 +540,24 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
         var buffer = packet.ToArray();
         var length = buffer.Length;
 
-        switch (_transportSender) {
-            case IReliableTransport reliableTransport when isReliable:
-                reliableTransport.SendReliable(buffer, 0, length);
-                break;
+        lock (_transportSendLock) {
+            switch (_transportSender) {
+                case IReliableTransport reliableTransport when isReliable:
+                    reliableTransport.SendReliable(buffer, 0, length);
+                    break;
 
-            case IEncryptedTransport transport:
-                transport.Send(buffer, 0, length);
-                break;
+                case IEncryptedTransport transport:
+                    transport.Send(buffer, 0, length);
+                    break;
 
-            case IReliableTransportClient reliableTransportClient when isReliable:
-                reliableTransportClient.SendReliable(buffer, 0, length);
-                break;
+                case IReliableTransportClient reliableTransportClient when isReliable:
+                    reliableTransportClient.SendReliable(buffer, 0, length);
+                    break;
 
-            case IEncryptedTransportClient transportClient:
-                transportClient.Send(buffer, 0, length);
-                break;
+                case IEncryptedTransportClient transportClient:
+                    transportClient.Send(buffer, 0, length);
+                    break;
+            }
         }
     }
 
@@ -542,6 +575,7 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
         IPacketData packetData
     ) {
         lock (Lock) {
+            Packet.Packet.ValidateSize(packetData);
             var addonPacketData = GetOrCreateAddonPacketData(addonId, packetIdSize);
             addonPacketData.PacketData[packetId] = packetData;
         }
@@ -564,20 +598,38 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
     ) where TPacketData : IPacketData, new() {
         lock (Lock) {
             var addonPacketData = GetOrCreateAddonPacketData(addonId, packetIdSize);
+            var isNew = false;
 
             if (!addonPacketData.PacketData.TryGetValue(packetId, out var existingPacketData)) {
                 existingPacketData = new PacketDataCollection<TPacketData>();
                 addonPacketData.PacketData[packetId] = existingPacketData;
+                isNew = true;
             }
 
             if (existingPacketData is not RawPacketDataCollection existingDataCollection) {
                 throw new InvalidOperationException("Could not add addon data with existing non-collection data");
             }
 
+            var previousCount = existingDataCollection.DataInstances.Count;
             if (packetData is RawPacketDataCollection packetDataAsCollection) {
                 existingDataCollection.DataInstances.AddRange(packetDataAsCollection.DataInstances);
             } else {
                 existingDataCollection.DataInstances.Add(packetData);
+            }
+
+            try {
+                Packet.Packet.ValidateSize(existingPacketData);
+            } catch {
+                var addedCount = existingDataCollection.DataInstances.Count - previousCount;
+                if (addedCount > 0) {
+                    existingDataCollection.DataInstances.RemoveRange(previousCount, addedCount);
+                }
+
+                if (isNew) {
+                    addonPacketData.PacketData.Remove(packetId);
+                }
+
+                throw;
             }
         }
     }
@@ -596,5 +648,36 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
         addonPacketData = new AddonPacketData(packetIdSize);
         CurrentUpdatePacket.SetSendingAddonPacketData(addonId, addonPacketData);
         return addonPacketData;
+    }
+
+    /// <summary>
+    /// Sends a slice packet immediately, bypassing the gameplay tick send loop.
+    /// </summary>
+    protected void SendSlicePacket(TOutgoing slicePacket) {
+        var rawPacket = new Packet.Packet();
+        lock (Lock) {
+            if (_requiresSequencing) {
+                slicePacket.Sequence = _localSequence;
+                slicePacket.Ack = _remoteSequence;
+
+                var ackField = slicePacket.AckField;
+                for (ushort i = 0; i < ConnectionManager.AckSize; i++) {
+                    var pastSequence = (ushort) (_remoteSequence - i - 1);
+                    ackField[i] = _receivedSequences!.Contains(pastSequence);
+                }
+            }
+
+            try {
+                slicePacket.CreatePacket(rawPacket);
+            } catch (Exception e) {
+                Logger.Error($"Failed to create slice packet: {e}");
+                return;
+            }
+
+            if (_requiresSequencing)
+                _localSequence++;
+        }
+
+        SendPacket(rawPacket, slicePacket.ContainsReliableData);
     }
 }

--- a/SSMP/Networking/UpdateManager.cs
+++ b/SSMP/Networking/UpdateManager.cs
@@ -651,7 +651,7 @@ internal abstract class UpdateManager<TOutgoing, TPacketId>
     }
 
     /// <summary>
-    /// Sends a slice packet immediately, bypassing the gameplay tick send loop.
+    /// Sends a slice packet immediately, bypassing the gameplay send loop.
     /// </summary>
     protected void SendSlicePacket(TOutgoing slicePacket) {
         var rawPacket = new Packet.Packet();


### PR DESCRIPTION
## Main changes

### 1. Fail fast on oversized normal packets

- `SSMP/Networking/Packet/Packet.cs`
- `SSMP/Networking/Packet/LengthCountingPacket.cs`
- `SSMP/Networking/UpdateManager.cs`

Added size validation before normal addon packet data is stored/sent.

Key effects:

- `Packet.WriteLength()` now throws if serialized size exceeds `ushort.MaxValue`
- `Packet.ValidateSize(...)` measures packet-data size without allocating a full packet
- normal addon data collection paths now validate aggregate size and roll back mutations if validation fails

This is the core truncation fix: oversized normal packets stop early and explicitly.

### 2. Add explicit chunk transport for large addon payloads

- `SSMP/Api/Client/Networking/IClientAddonNetworkSender.cs`
- `SSMP/Api/Server/Networking/IServerAddonNetworkSender.cs`
- `SSMP/Api/Client/Networking/ClientAddonNetworkSender.cs`
- `SSMP/Api/Server/Networking/ServerAddonNetworkSender.cs`
- `SSMP/Networking/Packet/ChunkAddonPacketBuilder.cs`
- `SSMP/Networking/Packet/Data/ChunkAddonData.cs`

Added new addon sender APIs for large payloads:

- client: `SendChunkData(...)`
- server: `SendChunkData(...)` and `BroadcastChunkData(...)`

Large addon payloads are now:

1. serialized as addon-local payload bytes
2. wrapped in a `ChunkAddonData` envelope containing `AddonId`, `PacketId`, and raw payload bytes
3. queued through the chunk sender instead of the normal update packet path

`ChunkAddonPacketBuilder` centralizes that flow and enforces both bounds:

- reject payloads that are too small to need chunk transport
- reject payloads that exceed `ConnectionManager.MaxChunkSize`

### 3. Register and dispatch chunked addon payloads through connection packets

- `SSMP/Networking/Packet/Connection/ClientConnectionPacket.cs`
- `SSMP/Networking/Packet/Connection/ServerConnectionPacket.cs`
- `SSMP/Networking/Packet/Connection/ClientConnectionPacketId.cs`
- `SSMP/Networking/Packet/Connection/ServerConnectionPacketId.cs`
- `SSMP/Networking/Packet/PacketManager.cs`
- `SSMP/Api/Client/Networking/ClientAddonNetworkReceiver.cs`
- `SSMP/Networking/Server/NetServer.cs`

Chunked addon payloads are transported as connection-packet envelopes rather than through the normal addon framing.
### 4. Gate large chunked addon traffic until connection setup is complete

- `SSMP/Networking/Client/ClientConnectionManager.cs`
- `SSMP/Networking/Server/ServerConnectionManager.cs`
- `SSMP/Networking/Client/NetClient.cs`
- `SSMP/Networking/Server/NetServer.cs`
- `SSMP/Networking/ConnectionManager.cs`

Added explicit pre-auth vs post-auth chunk behavior.

Key changes:

- new `AllowAddonChunks` gate in both connection managers
- new `MaxPreAuthChunkSize` cap before registration/auth completes
- client starts in pre-auth chunk mode and switches to full chunk mode only after successful connection setup
- server keeps clients in pre-auth chunk mode until registration succeeds

This prevents large addon chunk traffic from becoming available too early in the connection lifecycle.

### 5. Rewrite chunk sender/receiver internals to support the new flow safely

- `SSMP/Networking/Chunk/ChunkSender.cs`
- `SSMP/Networking/Chunk/ChunkReceiver.cs`
- `SSMP/Networking/Packet/Data/SliceData.cs`
- `SSMP/Networking/Packet/Data/SliceAckData.cs`
- `SSMP/Networking/Client/ClientUpdateManager.cs`
- `SSMP/Networking/Server/ServerUpdateManager.cs`
- `SSMP/Networking/UpdateManager.cs`

The chunk path needed more than just a new API. This PR also hardens the transport machinery it relies on.

Notable changes:

- Slice IDs and slice counts now use `ushort` instead of the old `byte`-based encoding.
- Slice packets are sent immediately instead of waiting for the normal update tick.
- The chunk sender now uses a fixed in-flight window plus resend pacing based on ACKs.
- Pooled arrays replace large fixed sender allocations to reduce GC pressure.
- The receiver now validates slice counts, slice bounds, chunk size, and stale partial chunks.
- The receiver stores per-slice segments and assembles the payload only after the full chunk arrives.
- Transport writes are serialized behind a dedicated send lock.

### 6. Tighten lifecycle and disposal behavior

- `SSMP/Api/Client/Networking/INetClient.cs`
- `SSMP/Networking/Client/NetClient.cs`
- `SSMP/Networking/Server/NetServerClient.cs`
- `SSMP/Networking/Server/NetServer.cs`
- `SSMP/Networking/UpdateManager.cs`

Chunk sending now owns background resources, so teardown had to be made explicit.

Key changes:

- `INetClient` now extends `IDisposable`
- `NetClient` disposes its `ChunkSender`
- `NetServerClient` now implements `IDisposable`
- server cleanup paths now dispose clients instead of only disconnecting them
- update-manager stop paths and chunk sender lifecycle paths were tightened to reduce join/deadlock/race issues

This is supporting work, but it is necessary. Large-payload transport is not safe if disconnect/shutdown can leave sender threads or shared state behind. This branch is bigger than the title alone suggests. It is not only a packet-size check. It also changes chunk protocol encoding,  chunk sender/receiver concurrency, connection-manager dispatch behavior, client/server lifecycle and disposal. 


> [!NOTE]
> XML comments / wording (i suck at those) by AI & the 2 boilerplate Packet classes
> Rest by me. Please review thoroughly as this is critical concurrent code :)