### PR TITLE
Allow chat box to be opened in main menu

### DIFF
--- a/SSMP/Ui/Chat/ChatBox.cs
+++ b/SSMP/Ui/Chat/ChatBox.cs
@@ -875,7 +875,7 @@ internal class ChatBox : IChatBox {
         if (gameManager == null) return false;
 
         var invFsm = gameManager.inventoryFSM;
-        if (invFsm == null) return false;
+        if (invFsm == null || !invFsm.Active) return false;
         var stateName = invFsm.ActiveStateName;
         return stateName != "Closed" && stateName != "Can Open Inventory?";
     }

--- a/SSMP/Ui/UiManager.cs
+++ b/SSMP/Ui/UiManager.cs
@@ -486,7 +486,7 @@ internal class UiManager : IUiManager {
     private void CreateInGameInterface(ComponentGroup parent) {
         _inGameGroup = new ComponentGroup(parent: parent);
 
-        var infoBoxGroup = new ComponentGroup(parent: _inGameGroup);
+        var infoBoxGroup = new ComponentGroup();
         InternalChatBox = new ChatBox(infoBoxGroup, _modSettings);
         InternalChatBox.ChatInputEvent += input => ChatInputEvent?.Invoke(input);
 


### PR DESCRIPTION
Fixes #81 by allowing the Chat Box to be opened on the main menu. Previously the check for whether the inventory was open through checking its FSM incorrectly disabled the chat box from opening. Additionally, the parent component group for the chat box was the "in-game" group, meaning that it couldn't show up even if the keybinds were pressed.